### PR TITLE
Capture GPS data and log completed jobs

### DIFF
--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -16,6 +16,7 @@ type Job = {
   job_type: "put_out" | "bring_in";
   bins?: string | null;
   notes?: string | null;
+  client_name: string | null;
 };
 
 function RoutePageContent() {
@@ -58,7 +59,29 @@ function RoutePageContent() {
     const rawJobs = params.get("jobs");
     const rawStart = params.get("start");
     try {
-      if (rawJobs) setJobs(JSON.parse(rawJobs));
+      if (rawJobs) {
+        const parsedJobs = JSON.parse(rawJobs);
+        if (Array.isArray(parsedJobs)) {
+          const normalizedJobs = parsedJobs.map((j: any): Job => {
+            const lat = typeof j?.lat === "number" ? j.lat : Number(j?.lat ?? 0);
+            const lng = typeof j?.lng === "number" ? j.lng : Number(j?.lng ?? 0);
+            return {
+              id: String(j?.id ?? ""),
+              address: String(j?.address ?? ""),
+              lat: Number.isFinite(lat) ? lat : 0,
+              lng: Number.isFinite(lng) ? lng : 0,
+              job_type: j?.job_type === "bring_in" ? "bring_in" : "put_out",
+              bins: j?.bins ?? null,
+              notes: j?.notes ?? null,
+              client_name:
+                j?.client_name !== undefined && j?.client_name !== null
+                  ? String(j.client_name)
+                  : null,
+            };
+          });
+          setJobs(normalizedJobs);
+        }
+      }
       if (rawStart) setStart(JSON.parse(rawStart));
     } catch (err) {
       console.error("Parse failed:", err);

--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -17,6 +17,7 @@ type Job = {
   job_type: "put_out" | "bring_in";
   bins?: string | null;
   notes?: string | null;
+  client_name: string | null;
 };
 
 const LIBRARIES: ("places")[] = ["places"];
@@ -130,7 +131,13 @@ function RunPageContent() {
           .eq("assigned_to", user.id)
           .eq("day_of_week", todayName);
 
-        if (!error && data) setJobs(data as Job[]);
+        if (!error && data) {
+          const normalized = (data as any[]).map((j) => ({
+            ...j,
+            client_name: j?.client_name ?? null,
+          }));
+          setJobs(normalized as Job[]);
+        }
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- propagate client names through staff job payloads
- watch geolocation on the proof page and upload proofs with GPS + notes metadata
- include every required field when inserting log records and ensure proof uploads get unique paths

## Testing
- npm run lint *(fails: Next.js prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cf10f780c883328a1dd765d1b8d027