### PR TITLE
Hide completed jobs from staff flow

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,6 @@
+export function getLocalISODate(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary
- mark proof submissions with the job id, update each job's `last_completed_on` date once proof is saved, and drop the completed stop from subsequent route/proof navigation
- filter staff run listings to exclude jobs already completed today using a shared helper that emits local `YYYY-MM-DD` strings
- organize proof uploads under slugified client/month/week directories with canonical JPEG filenames while persisting trimmed staff notes in the logs

## Testing
- npm run lint *(fails: command prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cf25b9ce848332889209cdf0e3e539