### PR TITLE
Adjust proof reference image resolution

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -207,32 +207,107 @@ export default function ProofPageContent() {
 
       setReferenceLookupComplete(false);
 
+      const sanitizePhotoPath = (input: string): string | null => {
+        if (!input) return null;
+
+        let sanitized = input.trim();
+        if (!sanitized.length) return null;
+
+        const publicSegment = "/storage/v1/object/public/proofs/";
+        const publicIndex = sanitized.indexOf(publicSegment);
+        if (publicIndex !== -1) {
+          sanitized = sanitized.slice(publicIndex + publicSegment.length);
+        }
+
+        if (sanitized.startsWith("public/")) {
+          sanitized = sanitized.slice("public/".length);
+        }
+
+        if (sanitized.startsWith("proofs/")) {
+          sanitized = sanitized.slice("proofs/".length);
+        }
+
+        sanitized = sanitized.split("?")[0]?.split("#")[0] ?? sanitized;
+        sanitized = sanitized.replace(/\\/g, "/");
+
+        try {
+          sanitized = decodeURIComponent(sanitized);
+        } catch {
+          sanitized = sanitized.replace(/%20/g, " ");
+        }
+
+        sanitized = sanitized.replace(/^\/+/, "").replace(/\/{2,}/g, "/").trim();
+
+        return sanitized.length ? sanitized : null;
+      };
+
       try {
         const bucket = supabase.storage.from("proofs");
-        const { data, error } = await bucket.createSignedUrl(
-          currentJob.photo_path,
-          60 * 60
-        );
+        const sanitizedPath = sanitizePhotoPath(currentJob.photo_path);
 
-        if (error) {
-          console.warn(
-            `Unable to load reference image at ${currentJob.photo_path}:`,
-            error
-          );
+        if (!sanitizedPath) {
           if (!isCancelled) {
             setReferenceUrls({ putOut: null, bringIn: null });
           }
+          return;
+        }
+
+        const getSignedUrlForPath = async (path: string) => {
+          const normalized = path.replace(/^\/+/, "");
+          const { data: signedData, error: signedError } = await bucket.createSignedUrl(
+            normalized,
+            60 * 60
+          );
+
+          if (signedError) {
+            console.warn(`Unable to load reference image at ${normalized}:`, signedError);
+            return null;
+          }
+
+          return signedData?.signedUrl ?? null;
+        };
+
+        const normalizedPath = sanitizedPath.replace(/^\/+/, "");
+
+        const derivesFolderFromNamedAsset = /\/(put out|bring in)\.jpe?g$/i.test(
+          normalizedPath
+        );
+        const lastSegment = normalizedPath.split("/").filter(Boolean).pop() ?? "";
+        const hasFileExtension = /\.[^./]+$/i.test(lastSegment);
+
+        let baseDir: string | null = null;
+
+        if (normalizedPath.endsWith("/")) {
+          baseDir = normalizedPath.replace(/\/+$/, "");
+        } else if (derivesFolderFromNamedAsset) {
+          const lastSlash = normalizedPath.lastIndexOf("/");
+          baseDir = lastSlash > -1 ? normalizedPath.slice(0, lastSlash) : null;
+        } else if (!hasFileExtension) {
+          baseDir = normalizedPath;
+        }
+
+        if (baseDir && !baseDir.trim().length) {
+          baseDir = null;
+        }
+
+        if (baseDir) {
+          const normalizedBaseDir = baseDir.replace(/^\/+/, "").replace(/\/+$/, "");
+
+          const [putOutUrl, bringInUrl] = await Promise.all([
+            getSignedUrlForPath(`${normalizedBaseDir}/Put Out.jpg`),
+            getSignedUrlForPath(`${normalizedBaseDir}/Bring In.jpg`),
+          ]);
+
+          if (!isCancelled) {
+            setReferenceUrls({ putOut: putOutUrl, bringIn: bringInUrl });
+          }
         } else {
+          const signedUrl = await getSignedUrlForPath(normalizedPath);
+
           if (!isCancelled) {
             setReferenceUrls({
-              putOut:
-                currentJob.job_type === "put_out"
-                  ? data?.signedUrl ?? PUT_OUT_PLACEHOLDER_URL
-                  : null,
-              bringIn:
-                currentJob.job_type === "bring_in"
-                  ? data?.signedUrl ?? BRING_IN_PLACEHOLDER_URL
-                  : null,
+              putOut: currentJob.job_type === "put_out" ? signedUrl : null,
+              bringIn: currentJob.job_type === "bring_in" ? signedUrl : null,
             });
           }
         }


### PR DESCRIPTION
## Summary
- sanitize stored proof photo paths and normalise references before requesting signed URLs
- derive instruction image directories when available and keep placeholder slots when files are missing
- ensure single-asset references only populate the matching instruction slot so the opposite side retains its placeholder

## Testing
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d094b2b9208332934a461bc7d0b11d