### PR TITLE
Align job handling with updated jobs schema

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -4,19 +4,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { getLocalISODate } from "@/lib/date";
-
-type Job = {
-  id: string;
-  address: string;
-  job_type: "put_out" | "bring_in";
-  bins?: string | null;
-  notes?: string | null;
-  lat: number;
-  lng: number;
-  photo_path: string | null;
-  client_name: string | null;
-  last_completed_on?: string | null;
-};
+import { normalizeJobs, type Job } from "@/lib/jobs";
 
 const TRANSPARENT_PIXEL =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
@@ -125,22 +113,7 @@ export default function ProofPageContent() {
       if (rawJobs) {
         const parsed = JSON.parse(rawJobs);
         if (Array.isArray(parsed)) {
-          const normalized = parsed.map((j: any): Job => ({
-            id: String(j?.id ?? ""),
-            address: String(j?.address ?? ""),
-            job_type: j?.job_type === "bring_in" ? "bring_in" : "put_out",
-            bins: j?.bins ?? null,
-            notes: j?.notes ?? null,
-            lat: Number(j?.lat ?? 0),
-            lng: Number(j?.lng ?? 0),
-            client_name: j?.client_name ?? null,
-            last_completed_on: j?.last_completed_on ?? null,
-            photo_path:
-              typeof j?.photo_path === "string" && j.photo_path.trim().length
-                ? j.photo_path
-                : null,
-          }));
-          setJobs(normalized);
+          setJobs(normalizeJobs(parsed));
         }
       }
       if (rawIdx) {

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -7,18 +7,7 @@ import SettingsDrawer from "@/components/UI/SettingsDrawer";
 import { darkMapStyle, lightMapStyle, satelliteMapStyle } from "@/lib/mapStyle";
 import { MapSettingsProvider, useMapSettings } from "@/components/Context/MapSettingsContext";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-
-type Job = {
-  id: string;
-  address: string;
-  lat: number;
-  lng: number;
-  job_type: "put_out" | "bring_in";
-  bins?: string | null;
-  notes?: string | null;
-  client_name: string | null;
-  photo_path: string | null;
-};
+import { normalizeJobs, type Job } from "@/lib/jobs";
 
 function RoutePageContent() {
   const supabase = createClientComponentClient();
@@ -63,28 +52,7 @@ function RoutePageContent() {
       if (rawJobs) {
         const parsedJobs = JSON.parse(rawJobs);
         if (Array.isArray(parsedJobs)) {
-          const normalizedJobs = parsedJobs.map((j: any): Job => {
-            const lat = typeof j?.lat === "number" ? j.lat : Number(j?.lat ?? 0);
-            const lng = typeof j?.lng === "number" ? j.lng : Number(j?.lng ?? 0);
-            return {
-              id: String(j?.id ?? ""),
-              address: String(j?.address ?? ""),
-              lat: Number.isFinite(lat) ? lat : 0,
-              lng: Number.isFinite(lng) ? lng : 0,
-              job_type: j?.job_type === "bring_in" ? "bring_in" : "put_out",
-              bins: j?.bins ?? null,
-              notes: j?.notes ?? null,
-              client_name:
-                j?.client_name !== undefined && j?.client_name !== null
-                  ? String(j.client_name)
-                  : null,
-              photo_path:
-                typeof j?.photo_path === "string" && j.photo_path.trim().length
-                  ? j.photo_path
-                  : null,
-            };
-          });
-          setJobs(normalizedJobs);
+          setJobs(normalizeJobs(parsedJobs));
         }
       }
       if (rawStart) setStart(JSON.parse(rawStart));

--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -9,19 +9,8 @@ import { useRouter } from "next/navigation";
 import SettingsDrawer from "@/components/UI/SettingsDrawer";
 import { darkMapStyle, lightMapStyle, satelliteMapStyle } from "@/lib/mapStyle";
 import { getLocalISODate } from "@/lib/date";
-
-type Job = {
-  id: string;
-  address: string;
-  lat: number;
-  lng: number;
-  job_type: "put_out" | "bring_in";
-  bins?: string | null;
-  notes?: string | null;
-  client_name: string | null;
-  last_completed_on?: string | null;
-  photo_path: string | null;
-};
+import { normalizeJobs, type Job } from "@/lib/jobs";
+import type { JobRecord } from "@/lib/database.types";
 
 const LIBRARIES: ("places")[] = ["places"];
 
@@ -132,30 +121,19 @@ function RunPageContent() {
 
         const { data, error } = await supabase
           .from("jobs")
-          .select("*")
+          .select<JobRecord>("*")
           .eq("assigned_to", user.id)
           .eq("day_of_week", todayName)
           .or(`last_completed_on.is.null,last_completed_on.neq.${todayDate}`);
 
         if (!error && data) {
-          const normalized = (data as any[]).map((j) => ({
-            ...j,
-            client_name: j?.client_name ?? null,
-            last_completed_on:
-              j?.last_completed_on !== undefined && j?.last_completed_on !== null
-                ? String(j.last_completed_on)
-                : null,
-            photo_path:
-              typeof j?.photo_path === "string" && j.photo_path.trim().length
-                ? j.photo_path
-                : null,
-          }));
+          const normalized = normalizeJobs<JobRecord>(data);
 
           const availableJobs = normalized.filter(
             (job) => !job.last_completed_on || job.last_completed_on !== todayDate
           );
 
-          setJobs(availableJobs as Job[]);
+          setJobs(availableJobs);
         }
       } finally {
         setLoading(false);

--- a/components/UI/SmartJobCard.tsx
+++ b/components/UI/SmartJobCard.tsx
@@ -1,17 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-
-type Job = {
-  id: string;
-  address: string;
-  job_type: "put_out" | "bring_in";
-  bins?: string | null;
-  notes?: string | null;
-  lat: number;
-  lng: number;
-  client_name: string | null;
-};
+import type { Job } from "@/lib/jobs";
 
 export default function SmartJobCard({
   job,
@@ -88,6 +78,12 @@ export default function SmartJobCard({
         user_id: user.id,
       });
       if (logErr) throw logErr;
+
+      const { error: updateErr } = await supabase
+        .from("jobs")
+        .update({ last_completed_on: dateStr })
+        .eq("id", job.id);
+      if (updateErr) throw updateErr;
 
       onCompleted();
     } catch (e: any) {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -16,3 +16,18 @@ export type ClientTokenRow = {
   token: string
   client: Client[]
 }
+
+export type JobRecord = {
+  id: string
+  address: string | null
+  lat: number | null
+  lng: number | null
+  last_completed_on: string | null
+  assigned_to: string | null
+  day_of_week: string | null
+  photo_path: string | null
+  client_name: string | null
+  bins: string | null
+  notes: string | null
+  job_type: string | null
+}

--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -1,0 +1,113 @@
+import type { JobRecord } from "./database.types";
+
+export type Job = {
+  id: string;
+  address: string;
+  lat: number;
+  lng: number;
+  job_type: "put_out" | "bring_in";
+  bins: string | null;
+  notes: string | null;
+  client_name: string | null;
+  photo_path: string | null;
+  last_completed_on: string | null;
+  assigned_to: string | null;
+  day_of_week: string | null;
+};
+
+function normalizeString(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "";
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (!value) {
+    return "";
+  }
+  return String(value).trim();
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  const normalized = normalizeString(value);
+  return normalized.length ? normalized : null;
+}
+
+function normalizeNumber(value: unknown): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeDate(value: unknown): string | null {
+  if (!value) return null;
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed.length) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      return trimmed;
+    }
+    if (/^\d{4}-\d{2}-\d{2}T/.test(trimmed)) {
+      return trimmed.slice(0, 10);
+    }
+    const dateMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (dateMatch) {
+      return dateMatch[1];
+    }
+    return trimmed;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  return null;
+}
+
+function normalizeJobType(value: unknown): "put_out" | "bring_in" {
+  const raw = normalizeString(value).toLowerCase();
+  if (!raw.length) return "put_out";
+
+  const cleaned = raw.replace(/[-\s]/g, "_");
+  if (
+    cleaned === "bring_in" ||
+    cleaned === "bringin" ||
+    cleaned === "bring" ||
+    cleaned === "in" ||
+    cleaned.endsWith("_in")
+  ) {
+    return "bring_in";
+  }
+
+  return "put_out";
+}
+
+export function normalizeJob<T extends Partial<JobRecord>>(record: T): Job {
+  return {
+    id: normalizeString(record.id),
+    address: normalizeString(record.address),
+    lat: normalizeNumber(record.lat),
+    lng: normalizeNumber(record.lng),
+    job_type: normalizeJobType(record.job_type),
+    bins: normalizeOptionalString(record.bins),
+    notes: normalizeOptionalString(record.notes),
+    client_name: normalizeOptionalString(record.client_name),
+    photo_path: normalizeOptionalString(record.photo_path),
+    last_completed_on: normalizeDate(record.last_completed_on),
+    assigned_to: normalizeOptionalString(record.assigned_to),
+    day_of_week: normalizeOptionalString(record.day_of_week),
+  };
+}
+
+export function normalizeJobs<T extends Partial<JobRecord>>(
+  records: T[] | null | undefined
+): Job[] {
+  if (!records) return [];
+  return records.map((record) => normalizeJob(record));
+}


### PR DESCRIPTION
## Summary
- add a shared Job type and normalization helpers that reflect the new jobs table
- update the staff run, route, and proof flows to consume normalized jobs from Supabase or query parameters
- ensure SmartJobCard updates last_completed_on after logging and share the new job typing

## Testing
- `npm run lint` *(fails: prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ae4160048332b589ae3c4363125a