### PR TITLE
Fix Supabase job query typing

### DIFF
--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -121,10 +121,11 @@ function RunPageContent() {
 
         const { data, error } = await supabase
           .from("jobs")
-          .select<JobRecord>("*")
+          .select("*")
           .eq("assigned_to", user.id)
           .eq("day_of_week", todayName)
-          .or(`last_completed_on.is.null,last_completed_on.neq.${todayDate}`);
+          .or(`last_completed_on.is.null,last_completed_on.neq.${todayDate}`)
+          .returns<JobRecord[]>();
 
         if (!error && data) {
           const normalized = normalizeJobs<JobRecord>(data);


### PR DESCRIPTION
## Summary
- remove the incorrect generic on the staff run Supabase query
- assert the response type using `returns<JobRecord[]>()` for proper typing

## Testing
- NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c604c6fc8332a733576e161fc626