### PR TITLE
Add stay logged in option and drawer sign out

### DIFF
--- a/app/auth/sign-in/SignInClient.tsx
+++ b/app/auth/sign-in/SignInClient.tsx
@@ -1,29 +1,54 @@
 // app/auth/sign-in/SignInClient.tsx
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import AuthLayout from "../layout";
 
 export default function SignInClient() {
   const router = useRouter();
-  const supabase = createClientComponentClient();
-
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [stayLoggedIn, setStayLoggedIn] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const storedPreference = window.localStorage.getItem("binbird-stay-logged-in");
+    if (storedPreference === "true") {
+      setStayLoggedIn(true);
+    }
+  }, []);
 
   async function handleSignIn(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setLoading(true);
+    const supabase = createClientComponentClient({ isSingleton: false });
+    const storage = (supabase.auth as {
+      storage?: { cookieOptions?: { maxAge?: number } };
+    }).storage;
+    if (storage?.cookieOptions) {
+      storage.cookieOptions.maxAge = stayLoggedIn
+        ? 60 * 60 * 24 * 30 * 1000
+        : 60 * 60 * 12 * 1000;
+    }
+
     const { error } = await supabase.auth.signInWithPassword({ email, password });
     if (error) {
       setError(error.message);
       setLoading(false);
       return;
+    }
+
+    if (typeof window !== "undefined") {
+      if (stayLoggedIn) {
+        window.localStorage.setItem("binbird-stay-logged-in", "true");
+      } else {
+        window.localStorage.removeItem("binbird-stay-logged-in");
+      }
     }
     router.push("/staff/run");
   }
@@ -51,6 +76,15 @@ export default function SignInClient() {
           className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-[#ff5757] text-black"
           required
         />
+        <label className="flex items-center gap-2 text-sm text-black">
+          <input
+            type="checkbox"
+            checked={stayLoggedIn}
+            onChange={(e) => setStayLoggedIn(e.target.checked)}
+            className="h-4 w-4 rounded border border-gray-400 text-[#ff5757] focus:ring-[#ff5757]"
+          />
+          Stay logged in
+        </label>
         <button
           type="submit"
           disabled={loading}

--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -2,15 +2,19 @@
 
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { useRouter } from "next/navigation";
+import { LogOut } from "lucide-react";
 import { useMapSettings } from "@/components/Context/MapSettingsContext";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export default function SettingsDrawer() {
   const supabase = createClientComponentClient();
+  const router = useRouter();
   const { mapStylePref, setMapStylePref, navPref, setNavPref } = useMapSettings();
 
   const [isOpen, setIsOpen] = useState(false);
   const [activePanel, setActivePanel] = useState<"nav" | "style" | null>(null);
+  const [logoutError, setLogoutError] = useState<string | null>(null);
 
   // Load user preferences from Supabase on mount, create row if it doesn't exist
   useEffect(() => {
@@ -55,6 +59,18 @@ export default function SettingsDrawer() {
     if (!error) {
       setActivePanel(null);
     }
+  };
+
+  const handleSignOut = async () => {
+    setLogoutError(null);
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      setLogoutError("We couldn't sign you out. Please try again.");
+      return;
+    }
+    setActivePanel(null);
+    setIsOpen(false);
+    router.push("/auth/sign-in");
   };
 
   return (
@@ -114,6 +130,17 @@ export default function SettingsDrawer() {
                 >
                   Map Style
                 </button>
+                <button
+                  type="button"
+                  onClick={handleSignOut}
+                  className="mt-2 inline-flex items-center justify-center gap-2 rounded-lg bg-[#ff5757] px-4 py-2 font-semibold text-black hover:opacity-90 transition"
+                >
+                  <LogOut className="h-4 w-4" />
+                  <span>Log Out</span>
+                </button>
+                {logoutError && (
+                  <p className="text-sm text-red-500">{logoutError}</p>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add a stay logged in checkbox to the sign-in form that remembers the selection and extends session cookies when enabled
- store the preference locally so the checkbox state persists and adjust Supabase cookie settings based on the selection
- add a logout action to the staff settings drawer hamburger menu with basic error handling and navigation back to sign-in

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d015b2688332913f6eecd6a0a43f