### PR TITLE
Restrict run screen jobs to incomplete assignments

### DIFF
--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -135,7 +135,7 @@ function RunPageContent() {
           .select("*")
           .eq("assigned_to", user.id)
           .eq("day_of_week", todayName)
-          .or(`last_completed_on.is.null,last_completed_on.neq.${todayDate}`);
+          .is("last_completed_on", null);
 
         if (!error && data) {
           const normalized = (data as any[]).map((j) => ({
@@ -152,7 +152,7 @@ function RunPageContent() {
           }));
 
           const availableJobs = normalized.filter(
-            (job) => !job.last_completed_on || job.last_completed_on !== todayDate
+            (job) => job.last_completed_on === null
           );
 
           setJobs(availableJobs as Job[]);


### PR DESCRIPTION
## Summary
- update the staff run Supabase query to fetch only jobs without a completion date
- tighten the available jobs filter so the list includes only incomplete jobs

## Testing
- ⚠️ `npm run lint` *(cannot complete: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d0176e188332a535bd397af1b394