### PR TITLE
Configure Supabase auth storage adapter for sign-in

### DIFF
--- a/app/auth/sign-in/SignInClient.tsx
+++ b/app/auth/sign-in/SignInClient.tsx
@@ -3,7 +3,13 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import {
+  BrowserCookieAuthStorageAdapter,
+  DEFAULT_COOKIE_OPTIONS,
+  createSupabaseClient,
+} from "@supabase/auth-helpers-shared";
+import type { DefaultCookieOptions } from "@supabase/auth-helpers-shared";
+import packageInfo from "@supabase/auth-helpers-nextjs/package.json";
 import AuthLayout from "../layout";
 
 export default function SignInClient() {
@@ -26,15 +32,29 @@ export default function SignInClient() {
     e.preventDefault();
     setError(null);
     setLoading(true);
-    const supabase = createClientComponentClient({ isSingleton: false });
-    const storage = (supabase.auth as {
-      storage?: { cookieOptions?: { maxAge?: number } };
-    }).storage;
-    if (storage?.cookieOptions) {
-      storage.cookieOptions.maxAge = stayLoggedIn
-        ? 60 * 60 * 24 * 30 * 1000
-        : 60 * 60 * 12 * 1000;
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      setError("Supabase environment variables are not configured.");
+      setLoading(false);
+      return;
     }
+
+    const cookieOptions: DefaultCookieOptions = {
+      ...DEFAULT_COOKIE_OPTIONS,
+      maxAge: stayLoggedIn ? 60 * 60 * 24 * 30 : 60 * 60 * 12,
+    };
+    const storage = new BrowserCookieAuthStorageAdapter(cookieOptions);
+
+    const supabase = createSupabaseClient(supabaseUrl, supabaseAnonKey, {
+      global: {
+        headers: {
+          "X-Client-Info": `${packageInfo.name}@${packageInfo.version}`,
+        },
+      },
+      auth: { storage },
+    });
 
     const { error } = await supabase.auth.signInWithPassword({ email, password });
     if (error) {


### PR DESCRIPTION
## Summary
- build the sign-in Supabase client with a BrowserCookieAuthStorageAdapter configured from the stay-logged-in preference
- set cookie max-age values in seconds and surface a clear error when Supabase env vars are missing

## Testing
- NEXT_PUBLIC_SUPABASE_URL="https://example.supabase.co" NEXT_PUBLIC_SUPABASE_ANON_KEY="example-key" npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0d954e0748332b4102f923e9610d2