### PR TITLE
Fix Supabase client setup on sign-in page

### DIFF
--- a/app/auth/sign-in/SignInClient.tsx
+++ b/app/auth/sign-in/SignInClient.tsx
@@ -9,6 +9,7 @@ import {
   createSupabaseClient,
 } from "@supabase/auth-helpers-shared";
 import type { DefaultCookieOptions } from "@supabase/auth-helpers-shared";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import packageInfo from "@supabase/auth-helpers-nextjs/package.json";
 import AuthLayout from "../layout";
 
@@ -33,13 +34,22 @@ export default function SignInClient() {
     setError(null);
     setLoading(true);
 
-    const supabase = createClientComponentClient({ isSingleton: false });
-    const authWithStorage = supabase.auth as unknown as {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      setError("Supabase environment variables are not configured.");
+      setLoading(false);
+      return;
+    }
+
+    const componentClient = createClientComponentClient({ isSingleton: false });
+    const authWithStorage = componentClient.auth as unknown as {
       storage?: { cookieOptions?: { maxAge?: number } };
     };
-    const storage = authWithStorage.storage;
-    if (storage?.cookieOptions) {
-      storage.cookieOptions.maxAge = stayLoggedIn
+    const existingStorage = authWithStorage.storage;
+    if (existingStorage?.cookieOptions) {
+      existingStorage.cookieOptions.maxAge = stayLoggedIn
         ? 60 * 60 * 24 * 30 * 1000
         : 60 * 60 * 12 * 1000;
     }
@@ -48,7 +58,7 @@ export default function SignInClient() {
       ...DEFAULT_COOKIE_OPTIONS,
       maxAge: stayLoggedIn ? 60 * 60 * 24 * 30 : 60 * 60 * 12,
     };
-    const storage = new BrowserCookieAuthStorageAdapter(cookieOptions);
+    const cookieStorage = new BrowserCookieAuthStorageAdapter(cookieOptions);
 
     const supabase = createSupabaseClient(supabaseUrl, supabaseAnonKey, {
       global: {
@@ -56,12 +66,15 @@ export default function SignInClient() {
           "X-Client-Info": `${packageInfo.name}@${packageInfo.version}`,
         },
       },
-      auth: { storage },
+      auth: { storage: cookieStorage },
     });
 
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-    if (error) {
-      setError(error.message);
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (signInError) {
+      setError(signInError.message);
       setLoading(false);
       return;
     }


### PR DESCRIPTION
## Summary
- import the Supabase client component helper and restructure sign-in client initialization to avoid duplicate identifiers
- add guards for required Supabase environment variables and reuse cookie storage configuration without redeclaration

## Testing
- npm run build *(fails: Supabase environment variables are not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ead731788332b3bd5735f4278c4a