### PR TITLE
Short-circuit middleware for Next.js assets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,14 +4,18 @@ import type { NextRequest } from 'next/server'
 import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
 
 export async function middleware(req: NextRequest) {
+  const pathname = req.nextUrl.pathname
+
+  if (pathname.startsWith('/_next/')) {
+    return NextResponse.next()
+  }
+
   const res = NextResponse.next()
   const supabase = createMiddlewareClient({ req, res })
 
   const {
     data: { session },
   } = await supabase.auth.getSession()
-
-  const pathname = req.nextUrl.pathname
 
   // Staff & Ops routes → require login
   if (!session && (pathname.startsWith('/staff') || pathname.startsWith('/ops'))) {


### PR DESCRIPTION
## Summary
- avoid creating a Supabase client in middleware for Next.js asset requests by returning early
- add a minimal ESLint config so `npm run lint` can run without interactive setup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b3a88d14833298d559483acf177d