### PR TITLE
Keep sign-in button in loading state until redirect

### DIFF
--- a/app/auth/sign-in/SignInClient.tsx
+++ b/app/auth/sign-in/SignInClient.tsx
@@ -43,6 +43,7 @@ export default function SignInClient() {
 
       if (signInError) {
         setError(signInError.message);
+        setLoading(false);
         return;
       }
 
@@ -56,7 +57,12 @@ export default function SignInClient() {
       }
 
       router.push("/staff/run");
-    } finally {
+    } catch (unknownError) {
+      const message =
+        unknownError instanceof Error
+          ? unknownError.message
+          : "An unexpected error occurred. Please try again.";
+      setError(message);
       setLoading(false);
     }
   }


### PR DESCRIPTION
## Summary
- keep the sign-in button in its loading state until the staff run page replaces the form
- reset the loading state whenever Supabase returns an error and surface unexpected failures gracefully

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d914a32483328fdb399c5da32a15