### PR TITLE
Close settings drawer on save

### DIFF
--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -58,6 +58,7 @@ export default function SettingsDrawer() {
 
     if (!error) {
       setActivePanel(null);
+      setIsOpen(false);
     }
   };
 


### PR DESCRIPTION
## Summary
- close the settings drawer when saving preferences so the hamburger popover dismisses

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d923dd2c8332b516201b800ea4cb