### PR TITLE
Fix navigation to next job after marking proof done

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -362,7 +362,7 @@ export default function ProofPageContent() {
         // go to route page for the next job
         const paramsObj = new URLSearchParams({
           jobs: JSON.stringify(jobs),
-          idx: String(nextIdx),
+          nextIdx: String(nextIdx),
           total: String(jobs.length),
         });
         router.push(`/staff/route?${paramsObj.toString()}`);


### PR DESCRIPTION
## Summary
- send the next job index when redirecting from proof back to the route view
- keep the route page aligned with the job progression after completing proof

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e981a4548332a13c1260cd86b046