### PR TITLE
Standardize user_profile primary key usage

### DIFF
--- a/app/auth/sign-up/SignUpClient.tsx
+++ b/app/auth/sign-up/SignUpClient.tsx
@@ -48,7 +48,7 @@ export default function SignUpClient() {
     const userId = data.user?.id;
     if (userId) {
       const { error: insertError } = await supabase.from("user_profile").insert({
-        id: userId,
+        user_id: userId,
         name,
         phone: `${countryCode}${phone}`,
         email,

--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -22,7 +22,7 @@ export default function Dashboard() {
       const { data: profile } = await supabase
         .from('user_profile')
         .select('role')
-        .eq('id', user.id)
+        .eq('user_id', user.id)
         .maybeSingle()
 
       setRole(profile?.role || 'staff')


### PR DESCRIPTION
## Summary
- insert user profiles using the user_id primary key during sign-up
- query dashboard roles by user_id to match the updated schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d20237f79883329689be141d1034a3