### PR TITLE
Redirect staff entry paths to run page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,6 +25,12 @@ export async function middleware(req: NextRequest) {
   if (session) {
     const { data: role, error } = await supabase.rpc('get_my_role')
     if (!error) {
+      if (
+        (pathname === '/' || pathname === '/auth' || pathname === '/auth/') &&
+        (role === 'staff' || role === 'admin')
+      ) {
+        return NextResponse.redirect(new URL('/staff/run', req.url))
+      }
       if (pathname.startsWith('/staff') && role !== 'staff' && role !== 'admin') {
         return NextResponse.redirect(new URL('/', req.url))
       }


### PR DESCRIPTION
## Summary
- redirect authenticated staff/admin users from the landing and auth pages to /staff/run
- keep existing staff/ops access checks intact while ensuring redirects happen before falling back to NextResponse.next

## Testing
- npm run lint
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d2fd33da948332b29cfaa637a3d155