### PR TITLE
Persist planned run state across staff workflow

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -6,6 +6,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { getLocalISODate } from "@/lib/date";
 import { normalizeJobs, type Job } from "@/lib/jobs";
 import { readRunSession, writeRunSession } from "@/lib/run-session";
+import { clearPlannedRun } from "@/lib/planned-run";
 
 const TRANSPARENT_PIXEL =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
@@ -357,6 +358,7 @@ export default function ProofPageContent() {
       // 👉 Decide where to navigate
       if (nextIdx >= jobs.length) {
         // all jobs done
+        clearPlannedRun();
         router.push("/staff/run/completed");
       } else {
         // go to route page for the next job

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -8,6 +8,7 @@ import { darkMapStyle, lightMapStyle, satelliteMapStyle } from "@/lib/mapStyle";
 import { MapSettingsProvider, useMapSettings } from "@/components/Context/MapSettingsContext";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { normalizeJobs, type Job } from "@/lib/jobs";
+import { readPlannedRun } from "@/lib/planned-run";
 
 function RoutePageContent() {
   const supabase = createClientComponentClient();
@@ -48,6 +49,15 @@ function RoutePageContent() {
 
   // Parse jobs + start
   useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = readPlannedRun();
+      if (stored) {
+        setJobs(stored.jobs.map((job) => ({ ...job })));
+        setStart({ lat: stored.start.lat, lng: stored.start.lng });
+        return;
+      }
+    }
+
     const rawJobs = params.get("jobs");
     const rawStart = params.get("start");
     try {

--- a/app/staff/run/completed/page.tsx
+++ b/app/staff/run/completed/page.tsx
@@ -11,6 +11,7 @@ import {
   readRunSession,
   RunSessionRecord,
 } from "@/lib/run-session";
+import { clearPlannedRun } from "@/lib/planned-run";
 
 const WEEKDAYS = [
   "Sunday",
@@ -101,6 +102,7 @@ function CompletedRunContent() {
     const stored = readRunSession();
     setRunData(stored);
     clearRunSession();
+    clearPlannedRun();
   }, []);
 
   useEffect(() => {

--- a/lib/planned-run.ts
+++ b/lib/planned-run.ts
@@ -1,0 +1,152 @@
+import type { Job } from "./jobs";
+
+export type PlannedRunLocation = { lat: number; lng: number };
+
+export type PlannedRunPayload = {
+  start: PlannedRunLocation;
+  end: PlannedRunLocation;
+  jobs: Job[];
+  startAddress: string | null;
+  endAddress: string | null;
+  createdAt: string;
+};
+
+const PLANNED_RUN_STORAGE_KEY = "binbird:planned-run";
+
+function isBrowser(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.sessionStorage !== "undefined"
+  );
+}
+
+function isLatLng(value: unknown): value is PlannedRunLocation {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { lat?: unknown }).lat === "number" &&
+    Number.isFinite((value as { lat: number }).lat) &&
+    typeof (value as { lng?: unknown }).lng === "number" &&
+    Number.isFinite((value as { lng: number }).lng)
+  );
+}
+
+function normalizeAddress(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function normalizeJob(value: Job): Job {
+  return {
+    id: String(value.id),
+    address: typeof value.address === "string" ? value.address : "",
+    lat: Number.isFinite(value.lat) ? value.lat : 0,
+    lng: Number.isFinite(value.lng) ? value.lng : 0,
+    job_type: value.job_type === "bring_in" ? "bring_in" : "put_out",
+    bins: typeof value.bins === "string" ? value.bins : null,
+    notes: typeof value.notes === "string" ? value.notes : null,
+    client_name:
+      typeof value.client_name === "string" && value.client_name.trim().length
+        ? value.client_name
+        : null,
+    photo_path:
+      typeof value.photo_path === "string" && value.photo_path.trim().length
+        ? value.photo_path
+        : null,
+    last_completed_on:
+      typeof value.last_completed_on === "string" &&
+      value.last_completed_on.trim().length
+        ? value.last_completed_on
+        : null,
+    assigned_to:
+      typeof value.assigned_to === "string" && value.assigned_to.trim().length
+        ? value.assigned_to
+        : null,
+    day_of_week:
+      typeof value.day_of_week === "string" && value.day_of_week.trim().length
+        ? value.day_of_week
+        : null,
+  };
+}
+
+export function readPlannedRun(): PlannedRunPayload | null {
+  if (!isBrowser()) return null;
+  const raw = window.sessionStorage.getItem(PLANNED_RUN_STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<PlannedRunPayload> | null;
+    if (!parsed || !isLatLng(parsed.start) || !isLatLng(parsed.end)) {
+      return null;
+    }
+
+    const jobsInput = Array.isArray(parsed.jobs) ? parsed.jobs : [];
+    const normalizedJobs = jobsInput
+      .map((job) => {
+        try {
+          return normalizeJob(job as Job);
+        } catch {
+          return null;
+        }
+      })
+      .filter((job): job is Job => job !== null);
+
+    if (!normalizedJobs.length) {
+      return null;
+    }
+
+    return {
+      start: parsed.start,
+      end: parsed.end,
+      jobs: normalizedJobs,
+      startAddress: normalizeAddress(parsed.startAddress),
+      endAddress: normalizeAddress(parsed.endAddress),
+      createdAt:
+        typeof parsed.createdAt === "string" && parsed.createdAt.length
+          ? parsed.createdAt
+          : new Date().toISOString(),
+    };
+  } catch (err) {
+    console.warn("Unable to parse planned run payload", err);
+    return null;
+  }
+}
+
+export function writePlannedRun(payload: PlannedRunPayload) {
+  if (!isBrowser()) return;
+
+  const normalized: PlannedRunPayload = {
+    start: isLatLng(payload.start) ? payload.start : { lat: 0, lng: 0 },
+    end: isLatLng(payload.end) ? payload.end : { lat: 0, lng: 0 },
+    jobs: Array.isArray(payload.jobs)
+      ? payload.jobs.map((job) => normalizeJob(job))
+      : [],
+    startAddress: normalizeAddress(payload.startAddress),
+    endAddress: normalizeAddress(payload.endAddress),
+    createdAt:
+      typeof payload.createdAt === "string" && payload.createdAt.length
+        ? payload.createdAt
+        : new Date().toISOString(),
+  };
+
+  if (!normalized.jobs.length) return;
+
+  try {
+    window.sessionStorage.setItem(
+      PLANNED_RUN_STORAGE_KEY,
+      JSON.stringify(normalized)
+    );
+  } catch (err) {
+    console.warn("Unable to persist planned run payload", err);
+  }
+}
+
+export function clearPlannedRun() {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.removeItem(PLANNED_RUN_STORAGE_KEY);
+  } catch (err) {
+    console.warn("Unable to clear planned run payload", err);
+  }
+}


### PR DESCRIPTION
## Summary
- add a sessionStorage helper for reading/writing the active planned run
- update the staff run planner to persist the plan, auto-redirect to the route page, and lock controls until cleared
- ensure the route, proof, and completion pages consume or clear the stored plan when appropriate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ffc71ba48332886039f279948b17