### PR TITLE
Add wing icon to shared header

### DIFF
--- a/components/UI/Header.tsx
+++ b/components/UI/Header.tsx
@@ -1,7 +1,14 @@
+import Image from 'next/image'
+
 export default function Header({ title }: { title: string }) {
   return (
-    <header className="mb-6 text-center">
-      <h1 className="text-3xl font-bold text-[var(--accent)]">{title}</h1>
+    <header className="mb-6 flex flex-col items-center">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center justify-center rounded-full bg-white/90 p-2 shadow-sm ring-1 ring-black/10">
+          <Image src="/wing-favicon.png" alt="BinBird wing" width={32} height={32} priority />
+        </div>
+        <h1 className="text-3xl font-bold text-[var(--accent)]">{title}</h1>
+      </div>
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- import `next/image` into the shared header
- add the reusable wing icon beside the header title with styling that works on light and dark dashboards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d30a19e788833284c37371d1d842d2