### PR TITLE
Only auto-redirect run planner after start

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -6,6 +6,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { getLocalISODate } from "@/lib/date";
 import { normalizeJobs, type Job } from "@/lib/jobs";
 import { readRunSession, writeRunSession } from "@/lib/run-session";
+import { clearPlannedRun } from "@/lib/planned-run";
 
 const TRANSPARENT_PIXEL =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
@@ -357,6 +358,7 @@ export default function ProofPageContent() {
       // 👉 Decide where to navigate
       if (nextIdx >= jobs.length) {
         // all jobs done
+        clearPlannedRun();
         router.push("/staff/run/completed");
       } else {
         // go to route page for the next job

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -8,6 +8,7 @@ import { darkMapStyle, lightMapStyle, satelliteMapStyle } from "@/lib/mapStyle";
 import { MapSettingsProvider, useMapSettings } from "@/components/Context/MapSettingsContext";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { normalizeJobs, type Job } from "@/lib/jobs";
+import { readPlannedRun } from "@/lib/planned-run";
 
 function RoutePageContent() {
   const supabase = createClientComponentClient();
@@ -48,6 +49,15 @@ function RoutePageContent() {
 
   // Parse jobs + start
   useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = readPlannedRun();
+      if (stored) {
+        setJobs(stored.jobs.map((job) => ({ ...job })));
+        setStart({ lat: stored.start.lat, lng: stored.start.lng });
+        return;
+      }
+    }
+
     const rawJobs = params.get("jobs");
     const rawStart = params.get("start");
     try {

--- a/app/staff/run/completed/page.tsx
+++ b/app/staff/run/completed/page.tsx
@@ -11,6 +11,7 @@ import {
   readRunSession,
   RunSessionRecord,
 } from "@/lib/run-session";
+import { clearPlannedRun } from "@/lib/planned-run";
 
 const WEEKDAYS = [
   "Sunday",
@@ -101,6 +102,7 @@ function CompletedRunContent() {
     const stored = readRunSession();
     setRunData(stored);
     clearRunSession();
+    clearPlannedRun();
   }, []);
 
   useEffect(() => {

--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -10,6 +10,12 @@ import SettingsDrawer from "@/components/UI/SettingsDrawer";
 import { darkMapStyle, lightMapStyle, satelliteMapStyle } from "@/lib/mapStyle";
 import { normalizeJobs, type Job } from "@/lib/jobs";
 import type { JobRecord } from "@/lib/database.types";
+import {
+  clearPlannedRun,
+  markPlannedRunStarted,
+  readPlannedRun,
+  writePlannedRun,
+} from "@/lib/planned-run";
 
 const LIBRARIES: ("places")[] = ["places"];
 
@@ -29,6 +35,22 @@ function RunPageContent() {
   const router = useRouter();
   const { mapStylePref } = useMapSettings();
   const mapRef = useRef<google.maps.Map | null>(null);
+  const hasRedirectedToRoute = useRef(false);
+
+  const redirectToRoute = useCallback(
+    (
+      jobsList: Job[],
+      startLocation: { lat: number; lng: number },
+      endLocation: { lat: number; lng: number }
+    ) => {
+      const params = new URLSearchParams();
+      params.set("jobs", JSON.stringify(jobsList));
+      params.set("start", JSON.stringify(startLocation));
+      params.set("end", JSON.stringify(endLocation));
+      router.replace(`/staff/route?${params.toString()}`);
+    },
+    [router]
+  );
 
   const [jobs, setJobs] = useState<Job[]>([]);
   const [ordered, setOrdered] = useState<Job[]>([]);
@@ -46,6 +68,7 @@ function RunPageContent() {
   const [endAuto, setEndAuto] = useState<google.maps.places.Autocomplete | null>(null);
 
   const [isPlanned, setIsPlanned] = useState(false);
+  const [plannerLocked, setPlannerLocked] = useState(true);
   const [resetCounter, setResetCounter] = useState(0);
   const [userMoved, setUserMoved] = useState(false);
   const [forceFit, setForceFit] = useState(false);
@@ -56,6 +79,33 @@ function RunPageContent() {
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
     libraries: LIBRARIES,
   });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const stored = readPlannedRun();
+    if (stored) {
+      setPlannerLocked(true);
+      setIsPlanned(true);
+      setJobs(stored.jobs);
+      setStart({ lat: stored.start.lat, lng: stored.start.lng });
+      setEnd({ lat: stored.end.lat, lng: stored.end.lng });
+      setStartAddress(stored.startAddress ?? "");
+      setEndAddress(stored.endAddress ?? "");
+      setOrdered(stored.jobs);
+      setRoutePath([]);
+      if (stored.startedAt && !hasRedirectedToRoute.current) {
+        hasRedirectedToRoute.current = true;
+        redirectToRoute(stored.jobs, stored.start, stored.end);
+      } else if (!stored.startedAt) {
+        hasRedirectedToRoute.current = false;
+      }
+      return;
+    }
+
+    hasRedirectedToRoute.current = false;
+    setPlannerLocked(false);
+  }, [redirectToRoute]);
 
   // ✅ Load today's jobs
   useEffect(() => {
@@ -251,10 +301,52 @@ function RunPageContent() {
     if (place.formatted_address) setEndAddress(place.formatted_address);
   };
 
+  const redirectExistingPlan = useCallback(() => {
+    const stored = readPlannedRun();
+    if (stored) {
+      markPlannedRunStarted();
+      hasRedirectedToRoute.current = true;
+      redirectToRoute(stored.jobs, stored.start, stored.end);
+      return true;
+    }
+
+    if (start && end && ordered.length) {
+      hasRedirectedToRoute.current = true;
+      redirectToRoute(ordered, start, end);
+      return true;
+    }
+
+    return false;
+  }, [end, ordered, redirectToRoute, start]);
+
+  const handleReset = useCallback(() => {
+    console.log("Resetting route");
+    clearPlannedRun();
+    hasRedirectedToRoute.current = false;
+    setRoutePath([]);
+    setOrdered([]);
+    setSameAsStart(false);
+    setEnd(null);
+    setEndAddress("");
+    setIsPlanned(false);
+    setPlannerLocked(false);
+    setResetCounter((c) => c + 1);
+    setUserMoved(false);
+    setForceFit(true);
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition((pos) =>
+        setStart({ lat: pos.coords.latitude, lng: pos.coords.longitude })
+      );
+    }
+  }, []);
+
   // Build route
   const buildRoute = async () => {
     console.log("Building route with:", { start, end, jobs });
-    if (!start || !end || jobs.length === 0) return alert("Need start, end, and jobs");
+    if (!start || !end || jobs.length === 0) {
+      alert("Need start, end, and jobs");
+      return;
+    }
     setRoutePath([]);
     setOrdered([]);
     setIsPlanned(false);
@@ -272,10 +364,32 @@ function RunPageContent() {
     console.log("Optimize API response:", opt);
     if (!resp.ok || !opt?.polyline) return alert("Could not build route.");
 
+    const plannedJobs = (opt.order || []).map((i: number) => jobs[i]);
+    if (!plannedJobs.length) {
+      alert("Could not build route.");
+      return;
+    }
+
     setRoutePath(polyline.decode(opt.polyline).map((c) => ({ lat: c[0], lng: c[1] })));
-    setOrdered((opt.order || []).map((i: number) => jobs[i]));
+    setOrdered(plannedJobs);
     setIsPlanned(true);
     setForceFit(true);
+
+    const normalizedStartAddress = startAddress.trim().length ? startAddress.trim() : null;
+    const normalizedEndAddress = endAddress.trim().length ? endAddress.trim() : null;
+
+    writePlannedRun({
+      start,
+      end,
+      jobs: plannedJobs,
+      startAddress: normalizedStartAddress,
+      endAddress: normalizedEndAddress,
+      createdAt: new Date().toISOString(),
+      startedAt: null,
+    });
+
+    setPlannerLocked(true);
+    hasRedirectedToRoute.current = false;
   };
 
   if (loading) return <div className="p-6 text-white bg-black">Loading jobs…</div>;
@@ -323,7 +437,7 @@ function RunPageContent() {
                 onChange={(e) => setStartAddress(e.target.value)}
                 placeholder="Start Location"
                 className="w-full px-3 py-2 rounded-lg text-black"
-                disabled={isPlanned}
+                disabled={isPlanned || plannerLocked}
               />
             </Autocomplete>
 
@@ -334,7 +448,7 @@ function RunPageContent() {
                 onChange={(e) => setEndAddress(e.target.value)}
                 placeholder="End Location"
                 className="w-full px-3 py-2 rounded-lg text-black"
-                disabled={sameAsStart || isPlanned}
+                disabled={sameAsStart || isPlanned || plannerLocked}
               />
             </Autocomplete>
 
@@ -344,30 +458,14 @@ function RunPageContent() {
                   type="checkbox"
                   checked={sameAsStart}
                   onChange={(e) => setSameAsStart(e.target.checked)}
-                  disabled={isPlanned}
+                  disabled={isPlanned || plannerLocked}
                 />
                 End same as Start
               </label>
 
               {isPlanned && (
                 <button
-                  onClick={() => {
-                    console.log("Resetting route");
-                    setRoutePath([]);
-                    setOrdered([]);
-                    setSameAsStart(false);
-                    setEnd(null);
-                    setEndAddress("");
-                    setIsPlanned(false);
-                    setResetCounter((c) => c + 1);
-                    setUserMoved(false);
-                    setForceFit(true);
-                    if (navigator.geolocation) {
-                      navigator.geolocation.getCurrentPosition((pos) =>
-                        setStart({ lat: pos.coords.latitude, lng: pos.coords.longitude })
-                      );
-                    }
-                  }}
+                  onClick={handleReset}
                   className="text-white text-sm font-semibold rounded-lg hover:bg-gray-700 transition"
                 >
                   Reset
@@ -390,18 +488,15 @@ function RunPageContent() {
                       : "bg-[#ff5757] hover:opacity-90"
                   }`}
                   onClick={() => {
-                    console.log("Button clicked, isPlanned:", isPlanned);
-                    if (isPlanned) {
-                      router.push(
-                        `/staff/route?jobs=${encodeURIComponent(
-                          JSON.stringify(ordered)
-                        )}&start=${encodeURIComponent(
-                          JSON.stringify(start)
-                        )}&end=${encodeURIComponent(JSON.stringify(end))}`
-                      );
-                    } else {
-                      buildRoute();
+                    console.log("Button clicked", {
+                      isPlanned,
+                      plannerLocked,
+                    });
+                    if (plannerLocked) {
+                      redirectExistingPlan();
+                      return;
                     }
+                    buildRoute();
                   }}
                 >
                   {isPlanned ? "Start Route" : "Plan Route"}

--- a/lib/planned-run.ts
+++ b/lib/planned-run.ts
@@ -1,0 +1,179 @@
+import type { Job } from "./jobs";
+
+export type PlannedRunLocation = { lat: number; lng: number };
+
+export type PlannedRunPayload = {
+  start: PlannedRunLocation;
+  end: PlannedRunLocation;
+  jobs: Job[];
+  startAddress: string | null;
+  endAddress: string | null;
+  createdAt: string;
+  startedAt: string | null;
+};
+
+const PLANNED_RUN_STORAGE_KEY = "binbird:planned-run";
+
+function isBrowser(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.sessionStorage !== "undefined"
+  );
+}
+
+function isLatLng(value: unknown): value is PlannedRunLocation {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { lat?: unknown }).lat === "number" &&
+    Number.isFinite((value as { lat: number }).lat) &&
+    typeof (value as { lng?: unknown }).lng === "number" &&
+    Number.isFinite((value as { lng: number }).lng)
+  );
+}
+
+function normalizeAddress(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function normalizeJob(value: Job): Job {
+  return {
+    id: String(value.id),
+    address: typeof value.address === "string" ? value.address : "",
+    lat: Number.isFinite(value.lat) ? value.lat : 0,
+    lng: Number.isFinite(value.lng) ? value.lng : 0,
+    job_type: value.job_type === "bring_in" ? "bring_in" : "put_out",
+    bins: typeof value.bins === "string" ? value.bins : null,
+    notes: typeof value.notes === "string" ? value.notes : null,
+    client_name:
+      typeof value.client_name === "string" && value.client_name.trim().length
+        ? value.client_name
+        : null,
+    photo_path:
+      typeof value.photo_path === "string" && value.photo_path.trim().length
+        ? value.photo_path
+        : null,
+    last_completed_on:
+      typeof value.last_completed_on === "string" &&
+      value.last_completed_on.trim().length
+        ? value.last_completed_on
+        : null,
+    assigned_to:
+      typeof value.assigned_to === "string" && value.assigned_to.trim().length
+        ? value.assigned_to
+        : null,
+    day_of_week:
+      typeof value.day_of_week === "string" && value.day_of_week.trim().length
+        ? value.day_of_week
+        : null,
+  };
+}
+
+export function readPlannedRun(): PlannedRunPayload | null {
+  if (!isBrowser()) return null;
+  const raw = window.sessionStorage.getItem(PLANNED_RUN_STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<PlannedRunPayload> | null;
+    if (!parsed || !isLatLng(parsed.start) || !isLatLng(parsed.end)) {
+      return null;
+    }
+
+    const jobsInput = Array.isArray(parsed.jobs) ? parsed.jobs : [];
+    const normalizedJobs = jobsInput
+      .map((job) => {
+        try {
+          return normalizeJob(job as Job);
+        } catch {
+          return null;
+        }
+      })
+      .filter((job): job is Job => job !== null);
+
+    if (!normalizedJobs.length) {
+      return null;
+    }
+
+    return {
+      start: parsed.start,
+      end: parsed.end,
+      jobs: normalizedJobs,
+      startAddress: normalizeAddress(parsed.startAddress),
+      endAddress: normalizeAddress(parsed.endAddress),
+      createdAt:
+        typeof parsed.createdAt === "string" && parsed.createdAt.length
+          ? parsed.createdAt
+          : new Date().toISOString(),
+      startedAt:
+        typeof parsed.startedAt === "string" && parsed.startedAt.length
+          ? parsed.startedAt
+          : null,
+    };
+  } catch (err) {
+    console.warn("Unable to parse planned run payload", err);
+    return null;
+  }
+}
+
+export function writePlannedRun(payload: PlannedRunPayload) {
+  if (!isBrowser()) return;
+
+  const normalized: PlannedRunPayload = {
+    start: isLatLng(payload.start) ? payload.start : { lat: 0, lng: 0 },
+    end: isLatLng(payload.end) ? payload.end : { lat: 0, lng: 0 },
+    jobs: Array.isArray(payload.jobs)
+      ? payload.jobs.map((job) => normalizeJob(job))
+      : [],
+    startAddress: normalizeAddress(payload.startAddress),
+    endAddress: normalizeAddress(payload.endAddress),
+    createdAt:
+      typeof payload.createdAt === "string" && payload.createdAt.length
+        ? payload.createdAt
+        : new Date().toISOString(),
+    startedAt:
+      typeof payload.startedAt === "string" && payload.startedAt.length
+        ? payload.startedAt
+        : null,
+  };
+
+  if (!normalized.jobs.length) return;
+
+  try {
+    window.sessionStorage.setItem(
+      PLANNED_RUN_STORAGE_KEY,
+      JSON.stringify(normalized)
+    );
+  } catch (err) {
+    console.warn("Unable to persist planned run payload", err);
+  }
+}
+
+export function clearPlannedRun() {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.removeItem(PLANNED_RUN_STORAGE_KEY);
+  } catch (err) {
+    console.warn("Unable to clear planned run payload", err);
+  }
+}
+
+export function markPlannedRunStarted(startedAtInput?: string) {
+  if (!isBrowser()) return;
+
+  const existing = readPlannedRun();
+  if (!existing) return;
+  if (existing.startedAt) return;
+
+  const startedAt =
+    typeof startedAtInput === "string" && startedAtInput.length
+      ? startedAtInput
+      : new Date().toISOString();
+
+  writePlannedRun({
+    ...existing,
+    startedAt,
+  });
+}


### PR DESCRIPTION
## Summary
- extend the planned run storage payload with a `startedAt` flag and helper to mark the route as started
- keep the staff run planner on the page after planning and only redirect automatically when a stored plan has already been started
- mark the stored plan as started when staff tap **Start Route**, ensuring later visits auto-redirect while fresh plans stay put

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ffc71ba48332886039f279948b17