### PR TITLE
Adjust route planning redirect behavior

### DIFF
--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -14,6 +14,7 @@ import {
   clearPlannedRun,
   readPlannedRun,
   writePlannedRun,
+  markPlannedRunStarted,
 } from "@/lib/planned-run";
 
 const LIBRARIES: ("places")[] = ["places"];
@@ -93,9 +94,11 @@ function RunPageContent() {
       setEndAddress(stored.endAddress ?? "");
       setOrdered(stored.jobs);
       setRoutePath([]);
-      if (!hasRedirectedToRoute.current) {
+      if (stored.hasStarted && !hasRedirectedToRoute.current) {
         hasRedirectedToRoute.current = true;
         redirectToRoute(stored.jobs, stored.start, stored.end);
+      } else if (!stored.hasStarted) {
+        hasRedirectedToRoute.current = false;
       }
       return;
     }
@@ -299,21 +302,41 @@ function RunPageContent() {
   };
 
   const redirectExistingPlan = useCallback(() => {
-    if (start && end && ordered.length) {
-      hasRedirectedToRoute.current = true;
-      redirectToRoute(ordered, start, end);
-      return true;
-    }
-
     const stored = readPlannedRun();
     if (stored) {
+      if (!stored.hasStarted) {
+        markPlannedRunStarted();
+      }
       hasRedirectedToRoute.current = true;
       redirectToRoute(stored.jobs, stored.start, stored.end);
       return true;
     }
 
+    if (start && end && ordered.length) {
+      const normalizedStartAddress = startAddress.trim().length
+        ? startAddress.trim()
+        : null;
+      const normalizedEndAddress = endAddress.trim().length
+        ? endAddress.trim()
+        : null;
+
+      writePlannedRun({
+        start,
+        end,
+        jobs: ordered,
+        startAddress: normalizedStartAddress,
+        endAddress: normalizedEndAddress,
+        createdAt: new Date().toISOString(),
+        hasStarted: true,
+      });
+
+      hasRedirectedToRoute.current = true;
+      redirectToRoute(ordered, start, end);
+      return true;
+    }
+
     return false;
-  }, [end, ordered, redirectToRoute, start]);
+  }, [end, endAddress, ordered, redirectToRoute, start, startAddress]);
 
   const handleReset = useCallback(() => {
     console.log("Resetting route");
@@ -381,11 +404,11 @@ function RunPageContent() {
       startAddress: normalizedStartAddress,
       endAddress: normalizedEndAddress,
       createdAt: new Date().toISOString(),
+      hasStarted: false,
     });
 
     setPlannerLocked(true);
-    hasRedirectedToRoute.current = true;
-    redirectToRoute(plannedJobs, start, end);
+    hasRedirectedToRoute.current = false;
   };
 
   if (loading) return <div className="p-6 text-white bg-black">Loading jobs…</div>;

--- a/lib/planned-run.ts
+++ b/lib/planned-run.ts
@@ -9,6 +9,7 @@ export type PlannedRunPayload = {
   startAddress: string | null;
   endAddress: string | null;
   createdAt: string;
+  hasStarted: boolean;
 };
 
 const PLANNED_RUN_STORAGE_KEY = "binbird:planned-run";
@@ -106,6 +107,7 @@ export function readPlannedRun(): PlannedRunPayload | null {
         typeof parsed.createdAt === "string" && parsed.createdAt.length
           ? parsed.createdAt
           : new Date().toISOString(),
+      hasStarted: Boolean(parsed.hasStarted),
     };
   } catch (err) {
     console.warn("Unable to parse planned run payload", err);
@@ -128,6 +130,7 @@ export function writePlannedRun(payload: PlannedRunPayload) {
       typeof payload.createdAt === "string" && payload.createdAt.length
         ? payload.createdAt
         : new Date().toISOString(),
+    hasStarted: Boolean(payload.hasStarted),
   };
 
   if (!normalized.jobs.length) return;
@@ -149,4 +152,16 @@ export function clearPlannedRun() {
   } catch (err) {
     console.warn("Unable to clear planned run payload", err);
   }
+}
+
+export function markPlannedRunStarted() {
+  if (!isBrowser()) return;
+
+  const existing = readPlannedRun();
+  if (!existing) return;
+
+  writePlannedRun({
+    ...existing,
+    hasStarted: true,
+  });
 }


### PR DESCRIPTION
## Summary
- add a hasStarted flag to the planned run session payload and helper to mark a run as started
- update the run planner to write the new flag and defer auto-redirecting until the user has started the saved route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d315eb3a548332aa0fbf69ca174725