### PR TITLE
Enforce staff run navigation restrictions

### DIFF
--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { LogOut } from "lucide-react";
 import { useMapSettings } from "@/components/Context/MapSettingsContext";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { clearPlannedRun } from "@/lib/planned-run";
 
 export default function SettingsDrawer() {
   const supabase = createClientComponentClient();
@@ -63,6 +64,7 @@ export default function SettingsDrawer() {
 
   const handleSignOut = async () => {
     setLogoutError(null);
+    clearPlannedRun();
     const { error } = await supabase.auth.signOut();
     if (error) {
       setLogoutError("We couldn't sign you out. Please try again.");

--- a/lib/active-run-cookie.ts
+++ b/lib/active-run-cookie.ts
@@ -1,0 +1,33 @@
+export const ACTIVE_RUN_COOKIE_NAME = "binbird-active-run";
+
+function setCookie(value: string, options?: { maxAge?: number }) {
+  if (typeof document === "undefined") return;
+
+  const segments = [
+    `${ACTIVE_RUN_COOKIE_NAME}=${value}`,
+    "path=/",
+    "SameSite=Lax",
+  ];
+
+  if (options?.maxAge !== undefined) {
+    segments.push(`Max-Age=${options.maxAge}`);
+  }
+
+  document.cookie = segments.join("; ");
+}
+
+export function setActiveRunCookie() {
+  setCookie("true");
+}
+
+export function clearActiveRunCookie() {
+  setCookie("", { maxAge: 0 });
+}
+
+export function syncActiveRunCookie(hasActiveRun: boolean) {
+  if (hasActiveRun) {
+    setActiveRunCookie();
+  } else {
+    clearActiveRunCookie();
+  }
+}

--- a/lib/planned-run.ts
+++ b/lib/planned-run.ts
@@ -1,4 +1,5 @@
 import type { Job } from "./jobs";
+import { clearActiveRunCookie, syncActiveRunCookie } from "./active-run-cookie";
 
 export type PlannedRunLocation = { lat: number; lng: number };
 
@@ -143,6 +144,8 @@ export function writePlannedRun(payload: PlannedRunPayload) {
   } catch (err) {
     console.warn("Unable to persist planned run payload", err);
   }
+
+  syncActiveRunCookie(normalized.hasStarted);
 }
 
 export function clearPlannedRun() {
@@ -152,6 +155,8 @@ export function clearPlannedRun() {
   } catch (err) {
     console.warn("Unable to clear planned run payload", err);
   }
+
+  clearActiveRunCookie();
 }
 
 export function markPlannedRunStarted() {

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+import { ACTIVE_RUN_COOKIE_NAME } from '@/lib/active-run-cookie'
 
 export async function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname
@@ -17,12 +18,43 @@ export async function middleware(req: NextRequest) {
     data: { session },
   } = await supabase.auth.getSession()
 
+  const normalizedPathname =
+    pathname !== '/' && pathname.endsWith('/')
+      ? pathname.slice(0, -1)
+      : pathname
+
+  const hasActiveRunCookie = req.cookies.get(ACTIVE_RUN_COOKIE_NAME)?.value === 'true'
+
+  const signedInRestrictedPaths = new Set([
+    '/',
+    '/auth',
+    '/auth/sign-in',
+    '/auth/sign-up',
+  ])
+
+  const activeRunBlockedPaths = new Set([
+    ...signedInRestrictedPaths,
+    '/staff/run',
+  ])
+
   // Staff & Ops routes → require login
   if (!session && (pathname.startsWith('/staff') || pathname.startsWith('/ops'))) {
-    return NextResponse.redirect(new URL('/auth', req.url))
+    const redirect = NextResponse.redirect(new URL('/auth', req.url))
+    if (hasActiveRunCookie) {
+      redirect.cookies.delete(ACTIVE_RUN_COOKIE_NAME)
+    }
+    return redirect
   }
 
   if (session) {
+    if (hasActiveRunCookie && activeRunBlockedPaths.has(normalizedPathname)) {
+      return NextResponse.redirect(new URL('/staff/route', req.url))
+    }
+
+    if (!hasActiveRunCookie && signedInRestrictedPaths.has(normalizedPathname)) {
+      return NextResponse.redirect(new URL('/staff/run', req.url))
+    }
+
     const { data: role, error } = await supabase.rpc('get_my_role')
     if (!error) {
       if (pathname.startsWith('/staff') && role !== 'staff' && role !== 'admin') {
@@ -32,6 +64,10 @@ export async function middleware(req: NextRequest) {
         return NextResponse.redirect(new URL('/', req.url))
       }
     }
+  }
+
+  if (!session && hasActiveRunCookie) {
+    res.cookies.delete(ACTIVE_RUN_COOKIE_NAME)
   }
 
   // Check client portal tokens


### PR DESCRIPTION
## Summary
- add an active run cookie helper to share run state across middleware and client code
- sync the cookie with planned run changes and clear it on logout to avoid stale state
- update middleware to redirect signed-in users away from auth/home pages and keep active runs on the staff route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d31cf2a710833293ac09cbc1232c38