### PR TITLE
Hide End Run option until run started

### DIFF
--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -86,8 +86,9 @@ export default function SettingsDrawer() {
     }
 
     const plannedRun = readPlannedRun();
+    const hasStartedPlan = Boolean(plannedRun?.hasStarted);
 
-    setHasActiveRun(hasActiveSession || Boolean(plannedRun));
+    setHasActiveRun(hasActiveSession || hasStartedPlan);
   }, []);
 
   // Load user preferences from Supabase on mount, create row if it doesn't exist
@@ -191,7 +192,9 @@ export default function SettingsDrawer() {
     const existingSession = readRunSession();
     const plannedRun = readPlannedRun();
 
-    if (!existingSession && (!plannedRun || plannedRun.jobs.length === 0)) {
+    const hasStartedPlan = Boolean(plannedRun?.hasStarted);
+
+    if (!existingSession && !hasStartedPlan) {
       setEndRunError("No active run to end.");
       return;
     }


### PR DESCRIPTION
## Summary
- only show the Settings drawer "End Run" action when a run is in progress or a planned run has been started
- prevent ending a run if no active session exists and the planned run has not been started

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3656dbeec8332b302566e23117353