### PR TITLE
Hide End Run option until run started

### DIFF
--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -86,8 +86,9 @@ export default function SettingsDrawer() {
     }
 
     const plannedRun = readPlannedRun();
+    const hasStartedPlan = Boolean(plannedRun?.hasStarted);
 
-    setHasActiveRun(hasActiveSession || Boolean(plannedRun));
+    setHasActiveRun(hasActiveSession || hasStartedPlan);
   }, []);
 
   // Load user preferences from Supabase on mount, create row if it doesn't exist
@@ -191,7 +192,9 @@ export default function SettingsDrawer() {
     const existingSession = readRunSession();
     const plannedRun = readPlannedRun();
 
-    if (!existingSession && (!plannedRun || plannedRun.jobs.length === 0)) {
+    const hasStartedPlan = Boolean(plannedRun?.hasStarted);
+
+    if (!existingSession && !hasStartedPlan) {
       setEndRunError("No active run to end.");
       return;
     }
@@ -396,11 +399,6 @@ export default function SettingsDrawer() {
                                   aria-pressed={isSelected}
                                 >
                                   <span>{option.label}</span>
-                                  {isSelected && (
-                                    <span className="text-xs font-medium uppercase tracking-[0.2em] text-black/70">
-                                      Selected
-                                    </span>
-                                  )}
                                 </button>
                               );
                             })}
@@ -424,11 +422,6 @@ export default function SettingsDrawer() {
                                   aria-pressed={isSelected}
                                 >
                                   <span>{option.label}</span>
-                                  {isSelected && (
-                                    <span className="text-xs font-medium uppercase tracking-[0.2em] text-black/70">
-                                      Selected
-                                    </span>
-                                  )}
                                 </button>
                               );
                             })}


### PR DESCRIPTION
## Summary
- only show the Settings drawer "End Run" action when a run is in progress or a planned run has been started
- prevent ending a run if no active session exists and the planned run has not been started
- remove the "Selected" label shown next to navigation and map style options in the Settings drawer pickers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3656dbeec8332b302566e23117353