### PR TITLE
Clear start marker when input is emptied

### DIFF
--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -486,7 +486,18 @@ function RunPageContent() {
               <input
                 type="text"
                 value={startAddress}
-                onChange={(e) => setStartAddress(e.target.value)}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setStartAddress(value);
+                  if (!value.trim()) {
+                    setStart(null);
+                    setForceFit(true);
+                    if (sameAsStart) {
+                      setEnd(null);
+                      setEndAddress("");
+                    }
+                  }
+                }}
                 placeholder="Where you are right now"
                 className="w-full px-3 py-2 rounded-lg text-black"
                 disabled={isPlanned || plannerLocked}


### PR DESCRIPTION
## Summary
- clear the stored start location when the start address input is emptied so the map marker resets
- also clear the end location when it was mirroring the start and force the map to refit bounds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d374daf35083329695844aeb335bc4