### PR TITLE
Adjust route page button colors

### DIFF
--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -300,7 +300,7 @@ function RoutePageContent() {
             <h2 className="text-lg font-bold relative z-10">{activeJob.address}</h2>
             <button
               onClick={() => window.open(navigateUrl, "_blank")}
-              className="w-full bg-sky-400 text-black px-4 py-2 rounded-lg font-semibold hover:opacity-90 relative z-10"
+              className="w-full bg-gray-800 text-[#ff5757] border border-[#ff5757] px-4 py-2 rounded-lg font-semibold transition hover:bg-gray-700 relative z-10"
             >
               Navigate
             </button>

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -300,13 +300,13 @@ function RoutePageContent() {
             <h2 className="text-lg font-bold relative z-10">{activeJob.address}</h2>
             <button
               onClick={() => window.open(navigateUrl, "_blank")}
-              className="w-full bg-[#ff5757] px-4 py-2 rounded-lg font-semibold hover:opacity-90 relative z-10"
+              className="w-full bg-sky-400 text-black px-4 py-2 rounded-lg font-semibold hover:opacity-90 relative z-10"
             >
               Navigate
             </button>
             <button
               onClick={handleArrivedAtLocation}
-              className="w-full bg-green-600 px-4 py-2 rounded-lg font-semibold hover:bg-green-700 relative z-10"
+              className="w-full bg-[#ff5757] text-white px-4 py-2 rounded-lg font-semibold hover:opacity-90 relative z-10"
             >
               Arrived At Location
             </button>

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -300,7 +300,7 @@ function RoutePageContent() {
             <h2 className="text-lg font-bold relative z-10">{activeJob.address}</h2>
             <button
               onClick={() => window.open(navigateUrl, "_blank")}
-              className="w-full bg-gray-800 text-[#ff5757] border border-[#ff5757] px-4 py-2 rounded-lg font-semibold transition hover:bg-gray-700 relative z-10"
+              className="w-full bg-black text-[#ff5757] px-4 py-2 rounded-lg font-semibold transition hover:bg-[#111111] relative z-10"
             >
               Navigate
             </button>


### PR DESCRIPTION
## Summary
- update route page call-to-action colors so the navigate button uses a light blue state and the arrival button matches the standard red styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3bf7f199c8332b390fa381fe5ecf0