### PR TITLE
Style staff portal to match client theme

### DIFF
--- a/app/staff/proof/page.tsx
+++ b/app/staff/proof/page.tsx
@@ -5,8 +5,16 @@ import ProofPageContent from "./proof-content";
 
 export default function ProofPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-white">Loading…</div>}>
-      <div className="h-dvh overflow-y-auto bg-black text-white">
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-black via-gray-950 to-red-950 px-6 text-white">
+          <div className="rounded-3xl border border-white/10 bg-black/70 px-6 py-4 text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+            Loading proof capture…
+          </div>
+        </div>
+      }
+    >
+      <div className="h-dvh overflow-y-auto bg-gradient-to-br from-black via-gray-950 to-red-950 text-white">
         <ProofPageContent />
       </div>
     </Suspense>

--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -251,21 +251,30 @@ export default function ProofPageContent() {
   const job = jobs[currentIdx];
 
   if (!job) {
-    return <div className="p-6 text-white">No job found.</div>;
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/70 px-6 py-5 text-center text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+          No job found.
+        </div>
+      </div>
+    );
   }
 
   function renderBins(bins: string | null | undefined) {
-    if (!bins) return <span className="text-gray-400">—</span>;
+    if (!bins)
+      return (
+        <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/50">—</span>
+      );
     return bins.split(",").map((b) => {
       const bin = b.trim().toLowerCase();
-      let color = "bg-gray-600";
-      if (bin.includes("red")) color = "bg-red-600";
-      else if (bin.includes("yellow")) color = "bg-yellow-500 text-black";
-      else if (bin.includes("green")) color = "bg-green-600";
+      let color = "bg-white/15 text-white";
+      if (bin.includes("red")) color = "bg-red-500/80 text-white";
+      else if (bin.includes("yellow")) color = "bg-yellow-400/90 text-black";
+      else if (bin.includes("green")) color = "bg-emerald-500/80 text-white";
       return (
         <span
           key={bin}
-          className={`${color} px-3 py-1 rounded-full text-xs font-semibold`}
+          className={`${color} rounded-full px-3 py-1 text-xs font-semibold shadow-sm shadow-black/30`}
         >
           {bin.charAt(0).toUpperCase() + bin.slice(1)}
         </span>
@@ -396,47 +405,50 @@ export default function ProofPageContent() {
     : TRANSPARENT_PIXEL;
 
   return (
-    <div className="relative flex min-h-full flex-col bg-black text-white">
-      <div className="flex-1 p-6 pb-32 space-y-4">
-        <h1 className="text-2xl font-bold text-[#ff5757]">
-          {job.job_type === "put_out" ? "Put Bins Out" : "Bring Bins In"}
-        </h1>
+    <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-6 px-4 pb-32 pt-10 text-white">
+      <section className="rounded-3xl border border-white/10 bg-black/75 p-6 shadow-2xl shadow-black/40 backdrop-blur">
+        <div className="flex flex-col gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-white/50">Job type</p>
+            <h1 className="mt-1 text-3xl font-semibold text-white">
+              {job.job_type === "put_out" ? "Put bins out" : "Bring bins in"}
+            </h1>
+            <p className="text-sm text-white/60">{job.address}</p>
+          </div>
 
-        <p className="text-lg font-semibold">{job.address}</p>
-
-        {/* Instructions dropdown */}
-        <div className="border border-gray-800 rounded-lg overflow-hidden">
           <button
             onClick={() => setShowInstructions((p) => !p)}
-            className="w-full flex justify-between items-center px-4 py-3 font-semibold bg-neutral-900 text-white hover:bg-neutral-800 transition"
+            className="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:border-binbird-red hover:bg-white/10"
           >
-            <span>Instructions</span>
-            <span>{showInstructions ? "▲" : "▼"}</span>
+            <span>Reference guidance</span>
+            <span className="text-xs uppercase tracking-[0.25em] text-white/60">
+              {showInstructions ? "Hide" : "View"}
+            </span>
           </button>
 
           {showInstructions && (
-            <div className="p-4 space-y-4 bg-neutral-800 text-white">
-              <div className="flex gap-4">
-                <div className="flex-1">
-                  <p className="text-sm text-gray-400 mb-2">Bins Out:</p>
+            <div className="grid gap-4 rounded-2xl border border-white/10 bg-black/60 p-4 text-sm text-white/70 shadow-inner shadow-black/40">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-3">
+                  <p className="text-xs uppercase tracking-[0.2em] text-white/50">Bins out</p>
                   <img
                     src={putOutImageSrc}
-                    alt="Bins Out Example"
-                    className="w-full aspect-[3/4] object-cover rounded-lg"
+                    alt="Bins out example"
+                    className="aspect-[3/4] w-full rounded-2xl border border-white/10 object-cover"
                   />
                 </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-400 mb-2">Bins In:</p>
+                <div className="space-y-3">
+                  <p className="text-xs uppercase tracking-[0.2em] text-white/50">Bins in</p>
                   <img
                     src={bringInImageSrc}
-                    alt="Bins In Example"
-                    className="w-full aspect-[3/4] object-cover rounded-lg"
+                    alt="Bins in example"
+                    className="aspect-[3/4] w-full rounded-2xl border border-white/10 object-cover"
                   />
                 </div>
               </div>
-              <div className="mt-4">
-                <p className="text-sm text-gray-400 mb-2">Placement Instructions:</p>
-                <p>
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-white/50">Placement instructions</p>
+                <p className="mt-2 text-sm text-white/60">
                   {job.job_type === "bring_in"
                     ? "Return bins neatly to their storage location. Ensure lids are closed and bins are not left blocking walkways or driveways."
                     : "Place bins neatly at the edge of the driveway with lids closed. Ensure bins do not block pedestrian walkways or driveways."}
@@ -444,22 +456,25 @@ export default function ProofPageContent() {
               </div>
             </div>
           )}
-        </div>
 
-        {job.notes && (
-          <div className="bg-neutral-900 rounded-lg p-4">
-            <p className="text-sm text-gray-400 mb-1">Property Notes:</p>
-            <p className="text-white font-medium">{job.notes}</p>
+          {job.notes && (
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/70">
+              <p className="text-xs uppercase tracking-[0.2em] text-white/50">Property notes</p>
+              <p className="mt-2 text-sm text-white/60">{job.notes}</p>
+            </div>
+          )}
+
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-white/50">Bins</p>
+            <div className="mt-2 flex flex-wrap gap-2">{renderBins(job.bins)}</div>
           </div>
-        )}
-
-        <div>
-          <p className="text-sm text-gray-400 mb-1">Bins:</p>
-          <div className="flex flex-wrap gap-2">{renderBins(job.bins)}</div>
         </div>
+      </section>
 
-        {/* Take photo */}
-        <div className="flex flex-col gap-2">
+      <section className="rounded-3xl border border-white/10 bg-black/75 p-6 shadow-2xl shadow-black/40 backdrop-blur">
+        <div className="flex flex-col gap-4">
+          <p className="text-xs uppercase tracking-[0.35em] text-white/50">Proof capture</p>
+
           <input
             type="file"
             accept="image/*"
@@ -478,47 +493,47 @@ export default function ProofPageContent() {
           />
           <label
             htmlFor="photo-upload"
-            className="w-full cursor-pointer bg-neutral-900 text-white px-4 py-2 rounded-lg text-center font-semibold hover:bg-neutral-800 transition"
+            className="inline-flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-sm font-semibold text-white transition hover:border-binbird-red hover:bg-white/20"
           >
-            {preview ? "Retake Photo ✓" : "Take Photo"}
+            {preview ? "Retake photo" : "Take photo"}
+            {preview && <span className="text-xs uppercase tracking-[0.3em] text-white/60">✓</span>}
           </label>
+
           {preview && (
-            <div className="flex justify-center mt-2">
+            <div className="overflow-hidden rounded-2xl border border-white/10">
               <img
                 src={preview}
                 alt="preview"
-                className="w-full aspect-[3/4] object-cover rounded-lg border border-gray-600"
+                className="aspect-[3/4] w-full object-cover"
               />
             </div>
           )}
-        </div>
 
-        {/* Leave note */}
-        <div>
-          <p className="text-sm text-gray-400 mb-1">Leave a note:</p>
-          <textarea
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            placeholder="Add any details..."
-            className="w-full p-3 rounded-lg bg-neutral-900 text-white min-h-[100px] placeholder-gray-500"
-          />
-        </div>
-
-        {gpsError && (
-          <div className="text-sm text-red-400">
-            <p>{gpsError}</p>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-white/50">Leave a note</p>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Add any helpful details for the client…"
+              className="mt-2 w-full min-h-[140px] rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder-white/50 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/40"
+            />
           </div>
-        )}
-      </div>
 
-      {/* Mark Done pinned bottom */}
-      <div className="absolute bottom-0 inset-x-0 p-4">
+          {gpsError && (
+            <div className="rounded-2xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+              {gpsError}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <div className="sticky bottom-8 z-20">
         <button
           onClick={handleMarkDone}
           disabled={!file || submitting}
-          className="w-full bg-[#ff5757] text-white px-4 py-3 rounded-lg font-bold disabled:opacity-50"
+          className="w-full rounded-3xl bg-binbird-red px-6 py-4 text-base font-semibold text-white shadow-2xl shadow-red-900/40 transition hover:bg-[#ff4747] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {submitting ? "Saving…" : "Mark Done"}
+          {submitting ? "Saving…" : "Mark done"}
         </button>
       </div>
     </div>

--- a/app/staff/route/page.tsx
+++ b/app/staff/route/page.tsx
@@ -5,7 +5,15 @@ import RoutePageContent from "./route-content";
 
 export default function StaffRoutePage() {
   return (
-    <Suspense fallback={<div className="p-6 text-white bg-black">Loading route…</div>}>
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-black via-gray-950 to-red-950 px-6 text-white">
+          <div className="rounded-3xl border border-white/10 bg-black/70 px-6 py-4 text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+            Loading your route…
+          </div>
+        </div>
+      }
+    >
       <RoutePageContent />
     </Suspense>
   );

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -243,8 +243,22 @@ function RoutePageContent() {
     );
   }
 
-  if (!isLoaded) return <div className="p-6 text-white bg-black">Loading map…</div>;
-  if (!activeJob) return <div className="p-6 text-white bg-black">No jobs found.</div>;
+  if (!isLoaded)
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/70 px-6 py-5 text-center text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+          Loading maps experience…
+        </div>
+      </div>
+    );
+  if (!activeJob)
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/70 px-6 py-5 text-center text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+          No jobs found for this run.
+        </div>
+      </div>
+    );
 
   const navigateUrl =
     navPref === "google"
@@ -261,80 +275,134 @@ function RoutePageContent() {
       : satelliteMapStyle;
 
   return (
-    <div className="flex flex-col min-h-screen max-w-xl mx-auto bg-black text-white">
-      <div className="relative h-[150vh]">
-        <GoogleMap
-          mapContainerStyle={{ width: "100%", height: "100%" }}
-          center={currentLocation || { lat: activeJob.lat, lng: activeJob.lng }}
-          zoom={13}
-          options={{
-            styles: styleMap,
-            disableDefaultUI: true,
-            zoomControl: false,
-            streetViewControl: false,
-            mapTypeControl: false,
-            fullscreenControl: false,
-            keyboardShortcuts: false,
-          }}
-          onLoad={(map) => setMapRef(map)}
-        >
-          {currentLocation && (
-            <Marker position={currentLocation} icon="http://maps.google.com/mapfiles/ms/icons/green-dot.png" />
-          )}
-          <Marker position={{ lat: activeJob.lat, lng: activeJob.lng }} icon="http://maps.google.com/mapfiles/ms/icons/ltblue-dot.png" />
-          {directions && (
-            <DirectionsRenderer
-              directions={directions}
-              options={{
-                suppressMarkers: true,
-                preserveViewport: true,
-                polylineOptions: { strokeColor: "#ff5757", strokeOpacity: 0.9, strokeWeight: 5 },
-              }}
+    <div className="flex min-h-screen w-full flex-col overflow-hidden">
+      <div className="relative flex-1">
+        <div className="absolute inset-0">
+          <GoogleMap
+            mapContainerStyle={{ width: "100%", height: "100%" }}
+            center={currentLocation || { lat: activeJob.lat, lng: activeJob.lng }}
+            zoom={13}
+            options={{
+              styles: styleMap,
+              disableDefaultUI: true,
+              zoomControl: false,
+              streetViewControl: false,
+              mapTypeControl: false,
+              fullscreenControl: false,
+              keyboardShortcuts: false,
+            }}
+            onLoad={(map) => setMapRef(map)}
+          >
+            {currentLocation && (
+              <Marker position={currentLocation} icon="http://maps.google.com/mapfiles/ms/icons/green-dot.png" />
+            )}
+            <Marker
+              position={{ lat: activeJob.lat, lng: activeJob.lng }}
+              icon="http://maps.google.com/mapfiles/ms/icons/ltblue-dot.png"
             />
-          )}
-        </GoogleMap>
+            {directions && (
+              <DirectionsRenderer
+                directions={directions}
+                options={{
+                  suppressMarkers: true,
+                  preserveViewport: true,
+                  polylineOptions: {
+                    strokeColor: "#ff5757",
+                    strokeOpacity: 0.9,
+                    strokeWeight: 5,
+                  },
+                }}
+              />
+            )}
+          </GoogleMap>
+        </div>
 
-        <div className="fixed inset-x-0 bottom-0 z-10">
-          <div className="bg-black w-full flex flex-col gap-3 p-6 relative">
-            <div className="absolute top-0 left-0 w-screen bg-[#ff5757]" style={{ height: "2px" }}></div>
-            <h2 className="text-lg font-bold relative z-10">{activeJob.address}</h2>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-56 bg-gradient-to-t from-black via-black/80 to-transparent" />
+      </div>
+
+      <div className="relative z-10 -mt-32 px-4 pb-16">
+        <div className="mx-auto w-full max-w-3xl rounded-3xl border border-white/10 bg-black/80 p-6 shadow-2xl shadow-black/40 backdrop-blur">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.35em] text-white/50">Current stop</p>
+              <h2 className="mt-1 text-2xl font-semibold text-white">{activeJob.address}</h2>
+              <p className="mt-2 text-sm text-white/60">
+                {isEndStop
+                  ? "Wrap up the run and head to your end location."
+                  : `Navigate to the next property and capture proof once you arrive.`}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/70">
+              <p className="text-xs uppercase tracking-[0.2em] text-white/50">Job {activeIdx + 1}</p>
+              <p className="mt-1 font-medium text-white">of {jobs.length}</p>
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-5 md:grid-cols-2">
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-white/5 bg-white/5 p-4 text-sm text-white/70">
+                <p className="text-xs uppercase tracking-[0.2em] text-white/50">Navigation preference</p>
+                <p className="mt-2 text-base font-medium text-white">{navPref === "waze" ? "Waze" : navPref === "apple" ? "Apple Maps" : "Google Maps"}</p>
+                <p className="mt-3 text-xs text-white/60">
+                  Launch directions in your preferred app with the button below.
+                </p>
+              </div>
+
+              <div className="rounded-2xl border border-white/5 bg-white/5 p-4 text-sm text-white/70">
+                <p className="text-xs uppercase tracking-[0.2em] text-white/50">Job notes</p>
+                <p className="mt-2 text-sm text-white/60">
+                  {activeJob.notes?.length ? activeJob.notes : "No special instructions for this stop."}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
               <button
                 onClick={() => window.open(navigateUrl, "_blank")}
-                className="w-full bg-neutral-900 text-white px-4 py-2 rounded-lg font-semibold transition hover:bg-neutral-800 relative z-10"
+                className="w-full rounded-2xl bg-white/10 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red"
               >
-                Navigate
+                Navigate with {navPref === "waze" ? "Waze" : navPref === "apple" ? "Apple Maps" : "Google Maps"}
               </button>
-            <button
-              onClick={handleArrivedAtLocation}
-              className="w-full bg-[#ff5757] text-white px-4 py-2 rounded-lg font-semibold hover:opacity-90 relative z-10"
-            >
-              Arrived At Location
-            </button>
+
+              <button
+                onClick={handleArrivedAtLocation}
+                className="w-full rounded-2xl bg-binbird-red px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-red-900/40 transition hover:bg-[#ff4747] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red"
+              >
+                Arrived at location
+              </button>
+
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/70">
+                <p className="text-xs uppercase tracking-[0.2em] text-white/50">What&apos;s next</p>
+                {jobs[activeIdx + 1] ? (
+                  <p className="mt-2 text-sm text-white/60">Upcoming: {jobs[activeIdx + 1].address}</p>
+                ) : (
+                  <p className="mt-2 text-sm text-white/60">You&apos;re on the final stop for today.</p>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>
-      
+
       {popupMsg && (
-        <div className="fixed inset-0 flex items-center justify-center z-50 bg-black/70">
-          <div className="bg-white text-black p-6 rounded-lg shadow-xl max-w-sm w-full text-center">
-            {/* Split into two lines */}
-            <p className="mb-2">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 px-4">
+          <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-black/90 p-6 text-center text-white shadow-2xl shadow-black/40 backdrop-blur">
+            <p className="text-base font-medium">
               {popupMsg.includes("(") ? popupMsg.split("(")[0] : popupMsg}
             </p>
             {popupMsg.includes("(") && (
-              <p className="text-sm text-gray-700">({popupMsg.split("(")[1]}</p>
+              <p className="mt-2 text-sm text-white/60">({popupMsg.split("(")[1]}</p>
             )}
-      
+
             <button
               onClick={() => setPopupMsg(null)}
-              className="mt-4 w-full bg-[#ff5757] text-white px-4 py-2 rounded-lg font-semibold"
+              className="mt-6 w-full rounded-2xl bg-binbird-red px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-red-900/40 transition hover:bg-[#ff4747] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red"
             >
               OK
             </button>
           </div>
         </div>
       )}
-
     </div>
   );
 }
@@ -342,7 +410,7 @@ function RoutePageContent() {
 export default function RoutePage() {
   return (
     <MapSettingsProvider>
-      <div className="relative min-h-screen bg-black text-white">
+      <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-black via-gray-950 to-red-950 text-white">
         <SettingsDrawer />
         <RoutePageContent />
       </div>

--- a/app/staff/run/page.tsx
+++ b/app/staff/run/page.tsx
@@ -5,7 +5,15 @@ import RunPageContent from "./run-content";
 
 export default function StaffRunPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-white bg-black">Loading run…</div>}>
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-black via-gray-950 to-red-950 px-6 text-white">
+          <div className="rounded-3xl border border-white/10 bg-black/70 px-6 py-4 text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+            Loading staff run experience…
+          </div>
+        </div>
+      }
+    >
       <RunPageContent />
     </Suspense>
   );

--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -46,7 +46,7 @@ const applyVictoriaAutocompleteLimits = (
 export default function RunPage() {
   return (
     <MapSettingsProvider>
-      <div className="relative min-h-screen bg-black text-white">
+      <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-black via-gray-950 to-red-950 text-white">
         <SettingsDrawer />
         <RunPageContent />
       </div>
@@ -468,129 +468,199 @@ function RunPageContent() {
     hasRedirectedToRoute.current = false;
   };
 
-  if (loading) return <div className="p-6 text-white bg-black">Loading jobs…</div>;
-  if (!isLoaded) return <div className="p-6 text-white bg-black">Loading map…</div>;
+  if (loading)
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/70 px-6 py-5 text-center text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+          Loading today&apos;s jobs…
+        </div>
+      </div>
+    );
+  if (!isLoaded)
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md rounded-3xl border border-white/10 bg-black/70 px-6 py-5 text-center text-sm font-medium text-white/80 shadow-2xl shadow-black/40 backdrop-blur">
+          Loading maps experience…
+        </div>
+      </div>
+    );
 
   const styleMap = mapStylePref === "Dark" ? darkMapStyle : mapStylePref === "Light" ? lightMapStyle : satelliteMapStyle;
 
   return (
-    <div className="flex flex-col h-screen w-full bg-black text-white overflow-hidden">
-
-      <div className="flex-grow relative">
-
-        <GoogleMap
-          key={resetCounter}
-          mapContainerStyle={{ width: "100%", height: "100%" }}
-          onLoad={(map) => { 
-            console.log("Google Map loaded"); 
-            mapRef.current = map; 
-            fitBoundsToMap(); 
-          }}
-          options={{ styles: styleMap, disableDefaultUI: true, zoomControl: false }}
-        >
-          {start && <Marker position={start} icon="http://maps.google.com/mapfiles/ms/icons/green-dot.png" />}
-          {!routePath.length
-            ? jobs.map((j) => {
-                console.log("Rendering job marker:", j.address, j.lat, j.lng);
-                return <Marker key={j.id} position={{ lat: j.lat, lng: j.lng }} icon="http://maps.google.com/mapfiles/ms/icons/ltblue-dot.png" />;
-              })
-            : ordered.map((j) => {
-                console.log("Rendering ordered marker:", j.address, j.lat, j.lng);
-                return <Marker key={j.id} position={{ lat: j.lat, lng: j.lng }} icon="http://maps.google.com/mapfiles/ms/icons/ltblue-dot.png" />;
-              })}
-          {end && <Marker position={end} icon="http://maps.google.com/mapfiles/ms/icons/red-dot.png" />}
-          {routePath.length > 0 && <Polyline path={routePath} options={{ strokeColor: "#ff5757", strokeOpacity: 0.9, strokeWeight: 5 }} />}
-        </GoogleMap>
-
-        {/* Overlay controls */}
-        <div className="fixed inset-x-0 bottom-0 z-10">
-          <div className="bg-black w-full flex flex-col gap-3 p-6 relative">
-            <div className="absolute top-0 left-0 w-screen bg-[#ff5757]" style={{ height: "2px" }}></div>
-            <h1 className="text-xl font-bold text-white relative z-10">Plan Run</h1>
-
-            <Autocomplete onLoad={setStartAuto} onPlaceChanged={onStartChanged}>
-              <input
-                type="text"
-                value={startAddress}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  setStartAddress(value);
-                  if (!value.trim()) {
-                    setStart(null);
-                    setForceFit(true);
-                    if (sameAsStart) {
-                      setEnd(null);
-                      setEndAddress("");
-                    }
-                  }
-                }}
-                placeholder="Where you are right now"
-                className="w-full px-3 py-2 rounded-lg text-black"
-                disabled={isPlanned || plannerLocked}
+    <div className="flex min-h-screen w-full flex-col overflow-hidden">
+      <div className="relative flex-1">
+        <div className="absolute inset-0">
+          <GoogleMap
+            key={resetCounter}
+            mapContainerStyle={{ width: "100%", height: "100%" }}
+            onLoad={(map) => {
+              console.log("Google Map loaded");
+              mapRef.current = map;
+              fitBoundsToMap();
+            }}
+            options={{
+              styles: styleMap,
+              disableDefaultUI: true,
+              zoomControl: false,
+            }}
+          >
+            {start && <Marker position={start} icon="http://maps.google.com/mapfiles/ms/icons/green-dot.png" />}
+            {!routePath.length
+              ? jobs.map((j) => {
+                  console.log("Rendering job marker:", j.address, j.lat, j.lng);
+                  return (
+                    <Marker
+                      key={j.id}
+                      position={{ lat: j.lat, lng: j.lng }}
+                      icon="http://maps.google.com/mapfiles/ms/icons/ltblue-dot.png"
+                    />
+                  );
+                })
+              : ordered.map((j) => {
+                  console.log("Rendering ordered marker:", j.address, j.lat, j.lng);
+                  return (
+                    <Marker
+                      key={j.id}
+                      position={{ lat: j.lat, lng: j.lng }}
+                      icon="http://maps.google.com/mapfiles/ms/icons/ltblue-dot.png"
+                    />
+                  );
+                })}
+            {end && <Marker position={end} icon="http://maps.google.com/mapfiles/ms/icons/red-dot.png" />}
+            {routePath.length > 0 && (
+              <Polyline
+                path={routePath}
+                options={{ strokeColor: "#ff5757", strokeOpacity: 0.9, strokeWeight: 5 }}
               />
-            </Autocomplete>
+            )}
+          </GoogleMap>
+        </div>
 
-            <Autocomplete onLoad={setEndAuto} onPlaceChanged={onEndChanged}>
-              <input
-                type="text"
-                value={endAddress}
-                onChange={(e) => setEndAddress(e.target.value)}
-                placeholder="Where you want to go after run"
-                className="w-full px-3 py-2 rounded-lg text-black"
-                disabled={sameAsStart || isPlanned || plannerLocked}
-              />
-            </Autocomplete>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-56 bg-gradient-to-t from-black via-black/80 to-transparent" />
+      </div>
 
-            <div className="flex items-center justify-between text-sm text-gray-300 mt-2">
-              <label className="flex items-center gap-2">
+      <div className="relative z-10 -mt-32 px-4 pb-16">
+        <div className="mx-auto w-full max-w-4xl rounded-3xl border border-white/10 bg-black/80 p-6 shadow-2xl shadow-black/40 backdrop-blur">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.35em] text-white/50">Today&apos;s run</p>
+              <h1 className="mt-1 text-2xl font-semibold text-white">Plan your route</h1>
+            </div>
+            {isPlanned && (
+              <button
+                onClick={handleReset}
+                className="rounded-xl border border-white/20 px-3 py-1 text-xs font-semibold text-white/70 transition hover:border-binbird-red hover:text-white"
+              >
+                Reset
+              </button>
+            )}
+          </div>
+
+          <div className="mt-6 grid gap-5 md:grid-cols-2">
+            <div className="space-y-4">
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Start from</p>
+                <Autocomplete onLoad={setStartAuto} onPlaceChanged={onStartChanged}>
+                  <input
+                    type="text"
+                    value={startAddress}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      setStartAddress(value);
+                      if (!value.trim()) {
+                        setStart(null);
+                        setForceFit(true);
+                        if (sameAsStart) {
+                          setEnd(null);
+                          setEndAddress("");
+                        }
+                      }
+                    }}
+                    placeholder="Where you are right now"
+                    className="w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-sm text-white placeholder-white/60 transition focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/40 disabled:opacity-60"
+                    disabled={isPlanned || plannerLocked}
+                  />
+                </Autocomplete>
+              </div>
+
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Finish at</p>
+                <Autocomplete onLoad={setEndAuto} onPlaceChanged={onEndChanged}>
+                  <input
+                    type="text"
+                    value={endAddress}
+                    onChange={(e) => setEndAddress(e.target.value)}
+                    placeholder="Where you want to go after the run"
+                    className="w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-sm text-white placeholder-white/60 transition focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/40 disabled:opacity-60"
+                    disabled={sameAsStart || isPlanned || plannerLocked}
+                  />
+                </Autocomplete>
+              </div>
+
+              <label className="flex items-center gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-white/80">
                 <input
                   type="checkbox"
                   checked={sameAsStart}
                   onChange={(e) => setSameAsStart(e.target.checked)}
                   disabled={isPlanned || plannerLocked}
+                  className="h-4 w-4 rounded border-white/40 bg-black/40 text-binbird-red focus:ring-binbird-red focus:ring-offset-0 disabled:opacity-60"
                 />
-                Finish at same place I started
+                <span>Finish at the same place I started</span>
               </label>
-
-              {isPlanned && (
-                <button
-                  onClick={handleReset}
-                  className="text-white text-sm font-semibold rounded-lg hover:bg-gray-700 transition"
-                >
-                  Reset
-                </button>
-              )}
             </div>
-            <div className="mt-4">
-              {jobs.length === 0 ? (
-                <button
-                  className="w-full px-4 py-2 rounded-lg font-semibold bg-[#ff5757] opacity-60 cursor-not-allowed"
-                  disabled
-                >
-                  All Jobs Completed
-                </button>
-              ) : !isPlanned ? (
-                // Plan Run button (grey)
-                <button
-                  className="w-full px-4 py-2 rounded-lg font-semibold bg-neutral-900 text-white hover:bg-neutral-800 transition"
-                  onClick={() => {
-                    console.log("Planning run…");
-                    buildRoute();
-                  }}
-                  disabled={plannerLocked}
-                >
-                  Plan Run
-                </button>
-              ) : (
-                // Start Run button (accent red)
-                <button
-                  className="w-full px-4 py-2 rounded-lg font-semibold bg-[#ff5757] text-white hover:opacity-90 transition"
-                  onClick={handleStartRun}
-                >
-                  Start Run
-                </button>
-              )}
-            </div>            
+
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-white/5 bg-white/5 p-4 text-sm text-white/70">
+                <p className="text-xs uppercase tracking-[0.2em] text-white/50">Jobs queued</p>
+                <p className="mt-2 text-3xl font-semibold text-white">{jobs.length}</p>
+                <p className="mt-2 text-sm text-white/60">
+                  We&apos;ll optimise your run order and provide turn-by-turn navigation when you start.
+                </p>
+              </div>
+
+              <div className="rounded-2xl border border-white/5 bg-white/5 p-4 text-sm text-white/70">
+                <p className="text-xs uppercase tracking-[0.2em] text-white/50">Route status</p>
+                <p className="mt-2 text-base font-medium text-white">
+                  {isPlanned ? "Run planned" : plannerLocked ? "Loading run plan" : "Ready to plan"}
+                </p>
+                {startAddress && (
+                  <p className="mt-3 text-xs text-white/60">Start: {startAddress}</p>
+                )}
+                {endAddress && (
+                  <p className="mt-1 text-xs text-white/60">Finish: {endAddress}</p>
+                )}
+              </div>
+
+              <div className="pt-2">
+                {jobs.length === 0 ? (
+                  <button
+                    className="w-full rounded-2xl bg-binbird-red/50 px-4 py-3 text-sm font-semibold text-white/80 cursor-not-allowed"
+                    disabled
+                  >
+                    All jobs completed
+                  </button>
+                ) : !isPlanned ? (
+                  <button
+                    className="w-full rounded-2xl bg-white/10 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => {
+                      console.log("Planning run…");
+                      buildRoute();
+                    }}
+                    disabled={plannerLocked}
+                  >
+                    Plan run
+                  </button>
+                ) : (
+                  <button
+                    className="w-full rounded-2xl bg-binbird-red px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-red-900/40 transition hover:bg-[#ff4747] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red"
+                    onClick={handleStartRun}
+                  >
+                    Start run
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -268,8 +268,7 @@ export default function SettingsDrawer() {
     <>
       {/* Header Bar */}
       <div
-        className="fixed top-0 left-0 w-full h-14 bg-black z-50 flex items-center px-4 shadow-md"
-        style={{ borderBottom: "2px solid #ff5757" }}
+        className="fixed left-1/2 top-6 z-40 flex w-full max-w-5xl -translate-x-1/2 justify-end px-4"
       >
         <button
           onClick={() => {
@@ -279,15 +278,19 @@ export default function SettingsDrawer() {
             setEndRunError(null);
             setLogoutError(null);
           }}
-          className="flex flex-col justify-center items-center h-10 w-10 p-2"
+          className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/20 bg-black/60 text-white shadow-xl shadow-black/40 backdrop-blur transition hover:border-binbird-red hover:text-binbird-red"
+          aria-label="Open staff settings"
         >
-          <span className="block w-full h-1 bg-white rounded mb-1"></span>
-          <span className="block w-full h-1 bg-white rounded mb-1"></span>
-          <span className="block w-full h-1 bg-white rounded"></span>
+          <span className="sr-only">Open settings</span>
+          <div className="flex flex-col items-center justify-center gap-1.5">
+            <span className="block h-0.5 w-6 rounded-full bg-current"></span>
+            <span className="block h-0.5 w-6 rounded-full bg-current"></span>
+            <span className="block h-0.5 w-6 rounded-full bg-current"></span>
+          </div>
         </button>
       </div>
 
-      <div className="w-full h-full pt-14">{/* Map goes here */}</div>
+      <div className="w-full h-full pt-24">{/* Map placeholder */}</div>
 
       {/* Full-Screen Drawer */}
       <AnimatePresence>
@@ -297,7 +300,7 @@ export default function SettingsDrawer() {
             animate={{ x: 0 }}
             exit={{ x: "-100%" }}
             transition={{ type: "tween" }}
-            className="fixed top-0 left-0 w-full h-full bg-black text-white z-50"
+            className="fixed inset-0 z-50 bg-gradient-to-br from-black via-gray-950 to-red-950 text-white backdrop-blur-sm"
           >
             {/* Close X top-left */}
             <button
@@ -305,22 +308,24 @@ export default function SettingsDrawer() {
                 dismissPanel();
                 setIsOpen(false);
               }}
-              className="absolute top-4 left-4 text-white text-3xl font-bold z-50"
+              className="absolute left-6 top-6 flex h-12 w-12 items-center justify-center rounded-2xl border border-white/20 bg-black/60 text-2xl font-bold text-white shadow-lg shadow-black/40 transition hover:border-binbird-red hover:text-binbird-red"
+              aria-label="Close settings"
             >
               &times;
             </button>
 
-            <div className="pt-16 px-6">
-              <h2 className="text-2xl font-bold mb-6">Settings</h2>
+            <div className="px-6 pt-24">
+              <h2 className="text-3xl font-semibold">Settings</h2>
 
               {/* Navigation & Map Style Buttons */}
-              <div className="flex flex-col gap-4">
+              <div className="mt-6 grid gap-4">
                 <button
                   onClick={() => handlePanelToggle("nav")}
                   className={clsx(
-                    "flex w-full items-center gap-3 text-left font-semibold uppercase text-sm transition",
-                    navButtonIsActive ? "text-[#ff5757]" : "text-white",
-                    "hover:text-[#ff5757]"
+                    "flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left text-sm font-semibold uppercase tracking-[0.25em] transition",
+                    navButtonIsActive
+                      ? "border-binbird-red/60 bg-binbird-red/20 text-white"
+                      : "text-white/70 hover:border-binbird-red/40 hover:text-white"
                   )}
                 >
                   <Navigation2 className="h-4 w-4" />
@@ -329,9 +334,10 @@ export default function SettingsDrawer() {
                 <button
                   onClick={() => handlePanelToggle("style")}
                   className={clsx(
-                    "flex w-full items-center gap-3 text-left font-semibold uppercase text-sm transition",
-                    mapButtonIsActive ? "text-[#ff5757]" : "text-white",
-                    "hover:text-[#ff5757]"
+                    "flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left text-sm font-semibold uppercase tracking-[0.25em] transition",
+                    mapButtonIsActive
+                      ? "border-binbird-red/60 bg-binbird-red/20 text-white"
+                      : "text-white/70 hover:border-binbird-red/40 hover:text-white"
                   )}
                 >
                   <Palette className="h-4 w-4" />
@@ -342,27 +348,25 @@ export default function SettingsDrawer() {
                     <button
                       type="button"
                       onClick={handleEndRun}
-                      className="flex w-full items-center gap-3 text-left font-semibold uppercase text-sm text-white transition hover:text-[#ff5757]"
+                      className="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left text-sm font-semibold uppercase tracking-[0.25em] text-white/80 transition hover:border-binbird-red hover:text-white"
                     >
                       <Flag className="h-4 w-4" />
                       <span>End Run</span>
                     </button>
                     {endRunError && (
-                      <p className="text-sm text-red-500">{endRunError}</p>
+                      <p className="text-sm text-red-400">{endRunError}</p>
                     )}
                   </>
                 )}
                 <button
                   type="button"
                   onClick={handleSignOut}
-                  className="flex w-full items-center gap-3 text-left font-semibold uppercase text-sm text-white transition hover:text-[#ff5757]"
+                  className="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left text-sm font-semibold uppercase tracking-[0.25em] text-white/80 transition hover:border-binbird-red hover:text-white"
                 >
                   <LogOut className="h-4 w-4" />
                   <span>Log Out</span>
                 </button>
-                {logoutError && (
-                  <p className="text-sm text-red-500">{logoutError}</p>
-                )}
+                {logoutError && <p className="text-sm text-red-400">{logoutError}</p>}
               </div>
             </div>
 
@@ -382,7 +386,7 @@ export default function SettingsDrawer() {
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: 16 }}
                     transition={{ type: "tween", duration: 0.18 }}
-                    className="flex max-h-[55vh] flex-col gap-5 overflow-hidden border-t-2 border-[#ff5757] bg-black/95 px-6 pb-6 pt-5 shadow-[0_-18px_40px_rgba(0,0,0,0.55)] backdrop-blur"
+                    className="flex max-h-[55vh] flex-col gap-5 overflow-hidden border-t border-white/10 bg-black/90 px-6 pb-6 pt-5 shadow-[0_-18px_40px_rgba(0,0,0,0.6)] backdrop-blur"
                   >
                     <div className="flex flex-1 flex-col overflow-hidden">
                       <p className="text-xs uppercase tracking-[0.35em] text-white/60">
@@ -400,14 +404,17 @@ export default function SettingsDrawer() {
                                   type="button"
                                   onClick={() => setDraftNavPref(option.key)}
                                   className={clsx(
-                                    "flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left text-base font-semibold uppercase tracking-wide transition",
+                                    "flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left text-sm font-medium transition",
                                     isSelected
-                                      ? "border-white bg-white text-black shadow-sm"
-                                      : "border-white/15 text-white/70 hover:border-white/30 hover:text-white"
+                                      ? "border-binbird-red/60 bg-binbird-red/20 text-white"
+                                      : "border-white/10 bg-white/5 text-white/70 hover:border-binbird-red/40 hover:text-white"
                                   )}
                                   aria-pressed={isSelected}
                                 >
                                   <span>{option.label}</span>
+                                  {isSelected && (
+                                    <Navigation2 className="h-4 w-4 text-binbird-red" />
+                                  )}
                                 </button>
                               );
                             })}
@@ -423,14 +430,15 @@ export default function SettingsDrawer() {
                                   type="button"
                                   onClick={() => setDraftMapStylePref(option.key)}
                                   className={clsx(
-                                    "flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left text-base font-semibold uppercase tracking-wide transition",
+                                    "flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left text-sm font-medium transition",
                                     isSelected
-                                      ? "border-white bg-white text-black shadow-sm"
-                                      : "border-white/15 text-white/70 hover:border-white/30 hover:text-white"
+                                      ? "border-binbird-red/60 bg-binbird-red/20 text-white"
+                                      : "border-white/10 bg-white/5 text-white/70 hover:border-binbird-red/40 hover:text-white"
                                   )}
                                   aria-pressed={isSelected}
                                 >
                                   <span>{option.label}</span>
+                                  {isSelected && <Palette className="h-4 w-4 text-binbird-red" />}
                                 </button>
                               );
                             })}
@@ -440,12 +448,20 @@ export default function SettingsDrawer() {
                     </div>
 
                     {/* Save Button */}
-                    <button
-                      onClick={saveSettings}
-                      className="mt-3 rounded-lg bg-[#ff5757] px-4 py-2 font-semibold transition hover:bg-[#ff6b6b]"
-                    >
-                      Save
-                    </button>
+                    <div className="flex flex-col gap-3 border-t border-white/10 pt-4">
+                      <button
+                        onClick={saveSettings}
+                        className="flex items-center justify-center rounded-2xl bg-binbird-red px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-red-900/40 transition hover:bg-[#ff4747]"
+                      >
+                        Save settings
+                      </button>
+                      <button
+                        onClick={dismissPanel}
+                        className="flex items-center justify-center rounded-2xl border border-white/20 px-4 py-3 text-sm font-semibold text-white/70 transition hover:border-white/40 hover:text-white"
+                      >
+                        Cancel
+                      </button>
+                    </div>
                   </motion.div>
                 </motion.div>
               )}


### PR DESCRIPTION
## Summary
- restyle the staff run planning experience with gradient chrome, glass panels, and updated form controls
- bring the route guidance view in line with the client palette, including refreshed cards, navigation actions, and modal styling
- modernize the proof capture flow and settings drawer with the same glassmorphism theme and sticky primary actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d493953a548332a4c1e0eafac426bc