### PR TITLE
Fix weekday lookup typing

### DIFF
--- a/components/client/ClientPortalProvider.tsx
+++ b/components/client/ClientPortalProvider.tsx
@@ -153,7 +153,7 @@ const DEFAULT_NOTIFICATION_PREFS: NotificationPreferences = {
   pushPropertyAlerts: true,
 }
 
-const WEEKDAY_LOOKUP = {
+const WEEKDAY_LOOKUP: Record<string, Day> = {
   sunday: 0,
   monday: 1,
   tuesday: 2,
@@ -161,7 +161,7 @@ const WEEKDAY_LOOKUP = {
   thursday: 4,
   friday: 5,
   saturday: 6,
-} as const satisfies Record<string, Day>
+}
 
 const parseLatLng = (value: string | null): { lat: number | null; lng: number | null } => {
   if (!value) return { lat: null, lng: null }


### PR DESCRIPTION
## Summary
- update the weekday lookup table to use a `Record<string, Day>` type so dynamic indexing remains type-safe

## Testing
- npm run build (fails: missing optional dependencies during webpack bundle)

------
https://chatgpt.com/codex/tasks/task_e_68d4cbdc50848332b1e8dfe5685f4535