### PR TITLE
Fix role lookup to filter by user_id

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -22,7 +22,7 @@ export default function Dashboard() {
       const { data: profile } = await supabase
         .from('user_profile')
         .select('role')
-        .eq('id', user.id)
+        .eq('user_id', user.id)
         .maybeSingle()
 
       setRole(profile?.role || 'staff')


### PR DESCRIPTION
## Summary
- ensure the dashboard fetches roles by matching the authenticated user's id against user_profile.user_id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5cd3be5c08332b7943c50ccacf469