### PR TITLE
Align client portal token relationships with client accounts

### DIFF
--- a/app/c/[token]/page.tsx
+++ b/app/c/[token]/page.tsx
@@ -12,7 +12,7 @@ export default async function ClientPortal({
 
   const { data, error } = await sb
     .from('client_token')
-    .select('token, client:client_id(id, name)')
+    .select('token, account:account_id(id, name)')
     .eq('token', token)
     .maybeSingle<ClientTokenRow>()
 
@@ -50,15 +50,14 @@ export default async function ClientPortal({
     logs: logsResult.data ?? [],
   }
 
-  const baseClient = data?.client?.[0]
-  const client = baseClient ? { ...baseClient, properties: portalData.properties } : baseClient
-  const properties = client?.properties ?? portalData.properties
+  const account = data?.account
+  const properties = portalData.properties
 
   return (
     <div className="container">
       <BackButton />
       <h2 className="text-xl font-semibold mb-4">
-        Client Portal — {client?.name}
+        Client Portal — {account?.name}
       </h2>
 
       {properties.length ? (

--- a/app/ops/tokens/page.tsx
+++ b/app/ops/tokens/page.tsx
@@ -6,25 +6,27 @@ export default async function TokensPage() {
   async function createToken(formData: FormData) {
     'use server'
     const sb = supabaseServer()
-    const clientId = formData.get('clientId') as string
+    const accountId = formData.get('accountId') as string
     const token = crypto.randomUUID().replace(/-/g, '')
-    await sb.from('client_token').insert({ client_id: clientId, token })
+    await sb
+      .from('client_token')
+      .insert({ account_id: accountId, token })
   }
 
   const sb = supabaseServer()
 
-  // Fetch all clients
-  const { data: clients, error: clientErr } = await sb
-    .from('client')
+  // Fetch all client accounts
+  const { data: accounts, error: accountErr } = await sb
+    .from('client_accounts')
     .select('id, name')
     .order('name')
 
-  if (clientErr) {
+  if (accountErr) {
     return (
       <div className="container">
         <BackButton />
-        <h2>Error loading clients</h2>
-        <p className="text-red-500">{clientErr.message}</p>
+        <h2>Error loading accounts</h2>
+        <p className="text-red-500">{accountErr.message}</p>
       </div>
     )
   }
@@ -32,7 +34,7 @@ export default async function TokensPage() {
   // Fetch all tokens
   const { data: tokens, error: tokenErr } = await sb
     .from('client_token')
-    .select('token, client:client_id(name)')
+    .select('token, account:account_id(name)')
     .order('created_at', { ascending: false })
 
   if (tokenErr) {
@@ -53,11 +55,11 @@ export default async function TokensPage() {
       {/* Token generator */}
       <form action={createToken} className="mb-6 space-x-2">
         <select
-          name="clientId"
+          name="accountId"
           className="border p-2 rounded"
           required
         >
-          {clients?.map((c: any) => (
+          {accounts?.map((c: any) => (
             <option key={c.id} value={c.id}>
               {c.name}
             </option>
@@ -74,7 +76,7 @@ export default async function TokensPage() {
         {tokens?.map((t: any) => (
           <li key={t.token}>
             <a target="_blank" href={`/c/${t.token}`}>
-              {t.client?.name} — /c/{t.token}
+              {t.account?.name} — /c/{t.token}
             </a>
           </li>
         ))}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1,20 +1,19 @@
 // lib/database.types.ts
 
 export type Property = {
-  id: number
-  address: string
-  notes?: string | null
+  id: string
+  address: string | null
+  notes: string | null
 }
 
 export type Client = {
-  id: number
-  name: string
-  properties: Property[]
+  id: string
+  name: string | null
 }
 
 export type ClientTokenRow = {
   token: string
-  client: Client[]
+  account: Client | null
 }
 
 export type JobRecord = {


### PR DESCRIPTION
## Summary
- update the ops token management page to create tokens against client accounts and show account names
- refresh the client portal token lookup to fetch the related account record
- align the shared database types with the UUID-based shapes returned by the Supabase RPCs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cd3c80bc83328bad57064c5af9ff