### PR TITLE
Propagate job account identifiers and log with account context

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -367,9 +367,14 @@ export default function ProofPageContent() {
   
       const staffNote = note.trim();
       const noteValue = staffNote.length ? staffNote : null;
-  
+
+      if (!job.account_id) {
+        throw new Error("Unable to submit proof: missing account identifier for job.");
+      }
+
       const { error: logErr } = await supabase.from("logs").insert({
         job_id: job.id,
+        account_id: job.account_id,
         client_name: job.client_name ?? null,
         address: job.address,
         task_type: job.job_type,

--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -183,7 +183,9 @@ function RunPageContent() {
         // Jobs query
         const { data, error } = await supabase
           .from("jobs")
-          .select("*")
+          .select(
+            "id, account_id, property_id, address, lat, lng, job_type, bins, notes, client_name, photo_path, last_completed_on, assigned_to, day_of_week"
+          )
           .eq("assigned_to", assigneeId)
           .ilike("day_of_week", todayName)
           .is("last_completed_on", null);

--- a/components/UI/SmartJobCard.tsx
+++ b/components/UI/SmartJobCard.tsx
@@ -63,7 +63,13 @@ export default function SmartJobCard({
       const propertyNote = typeof job.notes === "string" ? job.notes.trim() : "";
       const combinedNotes = propertyNote ? propertyNote : null;
 
+      if (!job.account_id) {
+        throw new Error("Unable to log completion: missing account identifier for job.");
+      }
+
       const { error: logErr } = await supabase.from("logs").insert({
+        job_id: job.id,
+        account_id: job.account_id,
         client_name: job.client_name ?? null,
         address: job.address,
         task_type: job.job_type,

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -19,6 +19,8 @@ export type ClientTokenRow = {
 
 export type JobRecord = {
   id: string
+  account_id: string | null
+  property_id: string | null
   address: string | null
   lat: number | null
   lng: number | null

--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -2,6 +2,8 @@ import type { JobRecord } from "./database.types";
 
 export type Job = {
   id: string;
+  account_id: string | null;
+  property_id: string | null;
   address: string;
   lat: number;
   lng: number;
@@ -91,6 +93,8 @@ function normalizeJobType(value: unknown): "put_out" | "bring_in" {
 export function normalizeJob<T extends Partial<JobRecord>>(record: T): Job {
   return {
     id: normalizeString(record.id),
+    account_id: normalizeOptionalString(record.account_id),
+    property_id: normalizeOptionalString(record.property_id),
     address: normalizeString(record.address),
     lat: normalizeNumber(record.lat),
     lng: normalizeNumber(record.lng),

--- a/lib/planned-run.ts
+++ b/lib/planned-run.ts
@@ -62,6 +62,14 @@ function normalizeAddress(value: unknown): string | null {
 function normalizeJob(value: Job): Job {
   return {
     id: String(value.id),
+    account_id:
+      typeof value.account_id === "string" && value.account_id.trim().length
+        ? value.account_id
+        : null,
+    property_id:
+      typeof value.property_id === "string" && value.property_id.trim().length
+        ? value.property_id
+        : null,
     address: typeof value.address === "string" ? value.address : "",
     lat: Number.isFinite(value.lat) ? value.lat : 0,
     lng: Number.isFinite(value.lng) ? value.lng : 0,


### PR DESCRIPTION
## Summary
- extend the shared job normalization/types to carry account and property identifiers
- ensure the staff run job fetch pulls the new columns so account context is available client-side
- include both job_id and account_id when inserting proof logs, guarding against missing identifiers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cd3da0bc83329514055c37c1d882