### PR TITLE
Restyle proof and completed run screens to match route theme

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -268,31 +268,27 @@ export default function ProofPageContent() {
 
     if (normalized.includes("red")) {
       return {
-        wrapper:
-          "border-red-500/80 bg-gradient-to-br from-red-600 via-red-600 to-red-700 text-white",
+        background: "bg-red-600",
         text: "text-white",
       };
     }
 
     if (normalized.includes("yellow")) {
       return {
-        wrapper:
-          "border-yellow-400/80 bg-gradient-to-br from-yellow-300 via-yellow-300 to-amber-400 text-black",
+        background: "bg-amber-300",
         text: "text-black",
       };
     }
 
     if (normalized.includes("green")) {
       return {
-        wrapper:
-          "border-emerald-500/80 bg-gradient-to-br from-emerald-600 via-emerald-600 to-emerald-700 text-white",
+        background: "bg-emerald-600",
         text: "text-white",
       };
     }
 
     return {
-      wrapper:
-        "border-neutral-500/70 bg-gradient-to-br from-neutral-700 via-neutral-700 to-neutral-800 text-white",
+      background: "bg-neutral-800",
       text: "text-white",
     };
   }
@@ -321,9 +317,9 @@ export default function ProofPageContent() {
       return (
         <div
           key={`${prefix}-${bin.toLowerCase()}-${idx}`}
-          className={`w-full rounded-xl border px-4 py-3 text-center text-base font-semibold tracking-tight transition-transform duration-150 ease-out hover:scale-[1.01] ${styles.wrapper}`}
+          className={`w-full rounded-lg px-4 py-3 text-center text-base font-semibold ${styles.background}`}
         >
-          <span className={`block font-semibold uppercase ${styles.text}`}>
+          <span className={`block font-semibold tracking-tight ${styles.text}`}>
             {getBinLabel(bin)}
           </span>
         </div>
@@ -502,16 +498,21 @@ export default function ProofPageContent() {
   const binCardsForInstructions = renderBinCards("instructions");
   const binCardsForQuickReference = renderBinCards("quick-reference");
   const subtleFallbackCard = (
-    <div className="w-full rounded-xl border border-neutral-700 bg-gradient-to-br from-neutral-700 via-neutral-700 to-neutral-800 px-4 py-3 text-center text-base font-semibold uppercase text-white">
+    <div className="w-full rounded-lg bg-neutral-900 px-4 py-3 text-center text-base font-semibold text-white">
       All Bins
     </div>
   );
 
   const quickReferenceContent = (
-    <div className="pt-1">
-      <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">
-        Bin colours today
-      </p>
+    <div className="space-y-3">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+          Bin colours today
+        </p>
+        <p className="text-sm text-gray-400">
+          Match these colours when you roll the bins.
+        </p>
+      </div>
       <div className="flex flex-col gap-2">
         {binCardsForQuickReference ?? subtleFallbackCard}
       </div>
@@ -519,208 +520,236 @@ export default function ProofPageContent() {
   );
 
   return (
-    <div className="relative flex min-h-full flex-col bg-gradient-to-br from-neutral-950 via-neutral-900 to-black text-white">
-      <div className="flex-1 p-6 pb-32 space-y-6">
-        <h1 className="text-3xl font-extrabold tracking-tight text-[#ff5757] drop-shadow-[0_6px_18px_rgba(255,87,87,0.35)]">
-          {job.job_type === "put_out" ? "Put Bins Out" : "Bring Bins In"}
-        </h1>
-
-        <p className="text-lg font-semibold text-gray-200">{job.address}</p>
-
-        <section className="space-y-4 rounded-2xl border border-neutral-800/70 bg-neutral-950/70 p-4 shadow-[0_25px_50px_rgba(0,0,0,0.45)] backdrop-blur">
-          <details className="border border-gray-800/80 rounded-xl overflow-hidden bg-neutral-900/60">
-            <summary className="px-4 py-3 font-bold bg-neutral-900/80 cursor-pointer">
-              Instructions
-            </summary>
-            <div className="p-4 bg-neutral-900/60 space-y-3">
-              <details className="border border-gray-800/80 rounded-xl overflow-hidden bg-neutral-900/60">
-                <summary className="px-4 py-3 font-bold bg-neutral-900/80 cursor-pointer">
-                  Step 1 – Start Spot
-                </summary>
-                <div className="p-4 bg-neutral-900/60 space-y-3 text-left">
-                  <div className="relative">
-                    <img
-                      src={startImageSrc}
-                      alt={`${startLocationLabel} example`}
-                      className="w-full aspect-[3/4] object-cover rounded-lg"
-                    />
-                    <span className="absolute top-3 left-3 rounded-full bg-[#ff5757] px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-lg">
-                      START HERE
-                    </span>
-                    <span className="absolute bottom-3 left-3 rounded bg-black/70 px-3 py-1 text-xs uppercase tracking-wide">
-                      {startLocationLabel}
-                    </span>
-                  </div>
-                  <p className="text-sm font-semibold text-white">{startBodyCopy.primary}</p>
-                  <p className="text-sm text-gray-300">{startBodyCopy.secondary}</p>
-                </div>
-              </details>
-
-              <details className="border border-gray-800/80 rounded-xl overflow-hidden bg-neutral-900/60">
-                <summary className="px-4 py-3 font-bold bg-neutral-900/80 cursor-pointer">
-                  Step 2 – Today’s Bins
-                </summary>
-                <div className="p-4 bg-neutral-900/60 space-y-3 text-left">
-                  <div className="flex flex-col gap-2">
-                    {binCardsForInstructions ?? subtleFallbackCard}
-                  </div>
-                  <div className="space-y-2">
-                    <p className="text-sm font-semibold text-white">
-                      Roll every bin in the colours shown above.
-                    </p>
-                    <p className="text-xs text-gray-300">Not sure? Take every bin.</p>
-                  </div>
-                </div>
-              </details>
-
-              <details className="border border-gray-800/80 rounded-xl overflow-hidden bg-neutral-900/60">
-                <summary className="px-4 py-3 font-bold bg-neutral-900/80 cursor-pointer">
-                  Step 3 – Move the Bins
-                </summary>
-                <div className="p-4 bg-neutral-900/60 text-left">
-                  <ul className="space-y-2 text-sm text-gray-300">
-                    {moveStepLines.map((line) => (
-                      <li key={line} className="flex items-start gap-2">
-                        <span aria-hidden="true" className="mt-0.5 text-[#ff5757]">
-                          ✓
-                        </span>
-                        <span>{line}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </details>
-
-              <details className="border border-gray-800/80 rounded-xl overflow-hidden bg-neutral-900/60">
-                <summary className="px-4 py-3 font-bold bg-neutral-900/80 cursor-pointer">
-                  Step 4 – Finish Spot
-                </summary>
-                <div className="p-4 bg-neutral-900/60 space-y-3 text-left">
-                  <div className="relative">
-                    <img
-                      src={endImageSrc}
-                      alt={`${endLocationLabel} example`}
-                      className="w-full aspect-[3/4] object-cover rounded-lg"
-                    />
-                    <span className="absolute top-3 left-3 rounded-full bg-green-500 px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-lg">
-                      END HERE
-                    </span>
-                    <span className="absolute bottom-3 left-3 rounded bg-black/70 px-3 py-1 text-xs uppercase tracking-wide">
-                      {endLocationLabel}
-                    </span>
-                  </div>
-                  <p className="text-sm font-semibold text-white">{endBodyCopy.primary}</p>
-                  <p className="text-sm text-gray-300">{endBodyCopy.secondary}</p>
-                </div>
-              </details>
-
-              <details className="border border-gray-800/80 rounded-xl overflow-hidden bg-neutral-900/60">
-                <summary className="px-4 py-3 font-bold bg-neutral-900/80 cursor-pointer">
-                  Step 5 – Final Check
-                </summary>
-                <div className="p-4 bg-neutral-900/60 text-left">
-                  <ul className="space-y-2 text-sm text-gray-300">
-                    {finalCheckLines.map((line) => (
-                      <li key={line} className="flex items-start gap-2">
-                        <span aria-hidden="true" className="mt-0.5 text-[#ff5757]">
-                          ✓
-                        </span>
-                        <span>{line}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </details>
-            </div>
-          </details>
-
-          {quickReferenceContent}
-        </section>
-
-        {job.notes && (
-          <div className="bg-neutral-900/80 border border-neutral-800/70 rounded-xl p-4 shadow-lg">
-            <p className="text-sm text-gray-400 mb-1">Property Notes:</p>
-            <p className="text-white font-medium">{job.notes}</p>
-          </div>
-        )}
-
-        {/* Take photo */}
-        <div className="flex flex-col gap-3 mt-10">
-          <input
-            type="file"
-            accept="image/*"
-            capture="environment"
-            id="photo-upload"
-            className="hidden"
-            ref={fileInputRef}
-            onChange={(e) => {
-              const f = e.target.files?.[0] ?? null;
-              setFile(f);
-              setPreview((prev) => {
-                if (prev) URL.revokeObjectURL(prev);
-                return f ? URL.createObjectURL(f) : null;
-              });
-            }}
+    <div className="flex min-h-screen flex-col bg-black text-white">
+      <div className="mx-auto flex w-full max-w-xl flex-1 flex-col px-6 pb-40 pt-12">
+        <div className="relative mb-8">
+          <div
+            className="absolute left-0 top-0 w-screen bg-[#ff5757]"
+            style={{ height: "2px" }}
           />
-          {preview && (
-            <div className="flex flex-col items-center gap-2">
-              <img
-                src={preview}
-                alt="preview"
-                className="w-full aspect-[3/4] object-cover rounded-xl border border-neutral-800/70 shadow-[0_15px_35px_rgba(0,0,0,0.45)]"
-                onClick={() => fileInputRef.current?.click()}
-              />
-              {!submitting && (
-                <button
-                  type="button"
-                  className="text-sm text-gray-300 underline"
+          <div className="space-y-2">
+            <h1 className="text-3xl font-extrabold tracking-tight text-[#ff5757]">
+              {job.job_type === "put_out" ? "Put Bins Out" : "Bring Bins In"}
+            </h1>
+            <p className="text-lg font-semibold text-gray-200">{job.address}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col gap-6">
+          <section className="space-y-4 rounded-2xl border border-white/10 bg-neutral-950/70 p-5">
+            <details className="overflow-hidden rounded-xl border border-white/10 bg-black/40">
+              <summary className="cursor-pointer px-4 py-3 text-base font-semibold text-white">
+                Instructions
+              </summary>
+              <div className="space-y-3 border-t border-white/10 bg-black/60 p-4">
+                <details className="overflow-hidden rounded-lg border border-white/10 bg-black/40">
+                  <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-white">
+                    Step 1 – Start Spot
+                  </summary>
+                  <div className="space-y-3 border-t border-white/10 bg-black/70 px-4 py-4 text-left">
+                    <div className="relative">
+                      <img
+                        src={startImageSrc}
+                        alt={`${startLocationLabel} example`}
+                        className="aspect-[3/4] w-full rounded-lg object-cover"
+                      />
+                      <span className="absolute top-3 left-3 rounded-full bg-[#ff5757] px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-lg">
+                        START HERE
+                      </span>
+                      <span className="absolute bottom-3 left-3 rounded bg-black/70 px-3 py-1 text-xs uppercase tracking-wide">
+                        {startLocationLabel}
+                      </span>
+                    </div>
+                    <p className="text-sm font-semibold text-white">
+                      {startBodyCopy.primary}
+                    </p>
+                    <p className="text-sm text-gray-300">
+                      {startBodyCopy.secondary}
+                    </p>
+                  </div>
+                </details>
+
+                <details className="overflow-hidden rounded-lg border border-white/10 bg-black/40">
+                  <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-white">
+                    Step 2 – Today’s Bins
+                  </summary>
+                  <div className="space-y-3 border-t border-white/10 bg-black/70 px-4 py-4 text-left">
+                    <div className="flex flex-col gap-2">
+                      {binCardsForInstructions ?? subtleFallbackCard}
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-sm font-semibold text-white">
+                        Roll every bin in the colours shown above.
+                      </p>
+                      <p className="text-xs text-gray-300">Not sure? Take every bin.</p>
+                    </div>
+                  </div>
+                </details>
+
+                <details className="overflow-hidden rounded-lg border border-white/10 bg-black/40">
+                  <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-white">
+                    Step 3 – Move the Bins
+                  </summary>
+                  <div className="border-t border-white/10 bg-black/70 px-4 py-4 text-left">
+                    <ul className="space-y-2 text-sm text-gray-300">
+                      {moveStepLines.map((line) => (
+                        <li key={line} className="flex items-start gap-2">
+                          <span aria-hidden="true" className="mt-0.5 text-[#ff5757]">
+                            ✓
+                          </span>
+                          <span>{line}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </details>
+
+                <details className="overflow-hidden rounded-lg border border-white/10 bg-black/40">
+                  <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-white">
+                    Step 4 – Finish Spot
+                  </summary>
+                  <div className="space-y-3 border-t border-white/10 bg-black/70 px-4 py-4 text-left">
+                    <div className="relative">
+                      <img
+                        src={endImageSrc}
+                        alt={`${endLocationLabel} example`}
+                        className="aspect-[3/4] w-full rounded-lg object-cover"
+                      />
+                      <span className="absolute top-3 left-3 rounded-full bg-green-500 px-3 py-1 text-xs font-semibold uppercase tracking-wide shadow-lg">
+                        END HERE
+                      </span>
+                      <span className="absolute bottom-3 left-3 rounded bg-black/70 px-3 py-1 text-xs uppercase tracking-wide">
+                        {endLocationLabel}
+                      </span>
+                    </div>
+                    <p className="text-sm font-semibold text-white">
+                      {endBodyCopy.primary}
+                    </p>
+                    <p className="text-sm text-gray-300">
+                      {endBodyCopy.secondary}
+                    </p>
+                  </div>
+                </details>
+
+                <details className="overflow-hidden rounded-lg border border-white/10 bg-black/40">
+                  <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-white">
+                    Step 5 – Final Check
+                  </summary>
+                  <div className="border-t border-white/10 bg-black/70 px-4 py-4 text-left">
+                    <ul className="space-y-2 text-sm text-gray-300">
+                      {finalCheckLines.map((line) => (
+                        <li key={line} className="flex items-start gap-2">
+                          <span aria-hidden="true" className="mt-0.5 text-[#ff5757]">
+                            ✓
+                          </span>
+                          <span>{line}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </details>
+              </div>
+            </details>
+          </section>
+
+          <div className="rounded-2xl border border-white/10 bg-neutral-950/70 p-5">
+            {quickReferenceContent}
+          </div>
+
+          {job.notes && (
+            <div className="rounded-2xl border border-white/10 bg-neutral-950/70 p-5">
+              <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+                Property notes
+              </p>
+              <p className="text-sm text-gray-200">{job.notes}</p>
+            </div>
+          )}
+
+          <div className="space-y-3">
+            <input
+              type="file"
+              accept="image/*"
+              capture="environment"
+              id="photo-upload"
+              className="hidden"
+              ref={fileInputRef}
+              onChange={(e) => {
+                const f = e.target.files?.[0] ?? null;
+                setFile(f);
+                setPreview((prev) => {
+                  if (prev) URL.revokeObjectURL(prev);
+                  return f ? URL.createObjectURL(f) : null;
+                });
+              }}
+            />
+            {preview && (
+              <div className="flex flex-col items-center gap-2">
+                <img
+                  src={preview}
+                  alt="preview"
+                  className="aspect-[3/4] w-full rounded-xl object-cover"
                   onClick={() => fileInputRef.current?.click()}
-                >
-                  Need a new photo?
-                </button>
-              )}
+                />
+                {!submitting && (
+                  <button
+                    type="button"
+                    className="text-sm font-semibold text-gray-300 underline underline-offset-4"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Need a new photo?
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-neutral-950/70 p-4">
+            <p className="mb-2 text-sm font-semibold text-gray-300">Leave a note</p>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Add any details..."
+              className="w-full min-h-[110px] rounded-lg bg-black/60 p-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#ff5757]/70"
+            />
+          </div>
+
+          {gpsError && (
+            <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+              <p>{gpsError}</p>
             </div>
           )}
         </div>
-
-        {/* Leave note */}
-        <div>
-          <p className="text-sm text-gray-400 mb-1">Leave a note:</p>
-          <textarea
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            placeholder="Add any details..."
-            className="w-full p-3 rounded-lg bg-neutral-900 text-white min-h-[100px] placeholder-gray-500"
-          />
-        </div>
-
-        {gpsError && (
-          <div className="text-sm text-red-400">
-            <p>{gpsError}</p>
-          </div>
-        )}
       </div>
 
-      {/* Mark Done pinned bottom */}
-      <div className="absolute bottom-0 inset-x-0 p-4">
-        <button
-          onClick={() => {
-            if (submitting) return;
-            if (!file) {
-              fileInputRef.current?.click();
-              return;
-            }
-            void handleMarkDone();
-          }}
-          disabled={submitting}
-          className={`w-full px-4 py-3 rounded-lg font-bold transition shadow-lg border ${
-            readyToSubmit
-              ? "bg-[#ff5757] text-white hover:opacity-90 border-[#ff7575]/60"
-              : "bg-neutral-800 text-white hover:bg-neutral-700 border-white/10"
-          } ${submitting ? "opacity-60 cursor-not-allowed" : ""}`}
-        >
-          {submitting ? "Saving…" : readyToSubmit ? "Mark Done" : "Take Photo"}
-        </button>
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-20">
+        <div className="bg-black">
+          <div className="mx-auto w-full max-w-xl px-6 pb-6 pt-4">
+            <div className="relative">
+              <div
+                className="absolute left-0 top-0 w-screen bg-[#ff5757]"
+                style={{ height: "2px" }}
+              />
+              <button
+                onClick={() => {
+                  if (submitting) return;
+                  if (!file) {
+                    fileInputRef.current?.click();
+                    return;
+                  }
+                  void handleMarkDone();
+                }}
+                disabled={submitting}
+                className={`pointer-events-auto w-full rounded-lg px-4 py-3 font-bold transition ${
+                  readyToSubmit
+                    ? "bg-[#ff5757] text-white hover:opacity-90"
+                    : "bg-neutral-900 text-white/70 hover:text-white hover:bg-neutral-800"
+                } ${submitting ? "cursor-not-allowed opacity-60" : ""}`}
+              >
+                {submitting ? "Saving…" : readyToSubmit ? "Mark Done" : "Take Photo"}
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/app/staff/run/completed/page.tsx
+++ b/app/staff/run/completed/page.tsx
@@ -274,123 +274,142 @@ function CompletedRunContent() {
   }, [runData]);
 
   return (
-    <div className="relative flex min-h-full flex-col bg-gradient-to-br from-neutral-950 via-neutral-900 to-black text-white">
-      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col px-6 pb-32 pt-8 sm:pt-12">
-        <header className="space-y-3 text-center sm:text-left">
-          <h1 className="text-3xl font-extrabold tracking-tight text-[#ff5757] drop-shadow-[0_8px_24px_rgba(255,87,87,0.45)]">
-            Run Complete!
-          </h1>
-          <p className="text-base text-gray-200 sm:text-lg">
-            <span className="block">Nice work there.</span>
-            <span className="block">Here&apos;s a quick recap of your shift.</span>
-          </p>
-        </header>
+    <div className="flex min-h-screen flex-col bg-black text-white">
+      <div className="mx-auto flex w-full max-w-xl flex-1 flex-col px-6 pb-40 pt-12">
+        <div className="relative mb-8 text-center sm:text-left">
+          <div
+            className="absolute left-0 top-0 w-screen bg-[#ff5757]"
+            style={{ height: "2px" }}
+          />
+          <div className="space-y-3">
+            <h1 className="text-3xl font-extrabold tracking-tight text-[#ff5757]">
+              Run Complete!
+            </h1>
+            <p className="text-base text-gray-200 sm:text-lg">
+              <span className="block">Nice work there.</span>
+              <span className="block">
+                Here&apos;s a quick recap of your shift.
+              </span>
+            </p>
+          </div>
+        </div>
 
-        <div className="mt-8 flex-1">
-          <section className="flex flex-col gap-4 rounded-2xl border border-neutral-800/70 bg-neutral-950/70 p-6 shadow-[0_25px_60px_rgba(0,0,0,0.55)] backdrop-blur">
-            <div className="flex items-center justify-between gap-2">
-              <h2 className="text-lg font-semibold text-white">Run Summary</h2>
-              {runData === undefined && (
-                <span className="text-sm text-gray-400">Loading…</span>
-              )}
-            </div>
+        <section className="flex flex-1 flex-col gap-4 rounded-2xl border border-white/10 bg-neutral-950/70 p-6">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-lg font-semibold text-white">Run Summary</h2>
+            {runData === undefined && (
+              <span className="text-sm text-gray-400">Loading…</span>
+            )}
+          </div>
 
-            {runData === undefined ? (
-              <p className="text-gray-300">
-                Hang tight while we gather the final numbers.
-              </p>
-            ) : runData === null ? (
-              <p className="text-gray-300">
-                We couldn&apos;t find run details for this session, but your proofs
-                were saved successfully.
-              </p>
-            ) : (
-              <div className="space-y-4">
-                <div className="divide-y divide-white/10 text-gray-100">
-                  {/* Duration */}
-                  <div className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Duration</p>
-                    <p className="text-xl font-semibold text-white">
-                      {derivedStats.durationLabel}
-                    </p>
-                  </div>
+          {runData === undefined ? (
+            <p className="text-sm text-gray-300">
+              Hang tight while we gather the final numbers.
+            </p>
+          ) : runData === null ? (
+            <p className="text-sm text-gray-300">
+              We couldn&apos;t find run details for this session, but your proofs
+              were saved successfully.
+            </p>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-xl bg-black/50 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+                    Duration
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {derivedStats.durationLabel}
+                  </p>
+                </div>
 
-                  {/* Jobs completed */}
-                  <div className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Jobs completed</p>
-                    <p className="text-xl font-semibold text-white">
-                      {derivedStats.jobsCompleted ?? "—"}
-                      {derivedStats.totalJobs !== undefined &&
-                        derivedStats.totalJobs !== derivedStats.jobsCompleted &&
-                        derivedStats.totalJobs !== 0 && (
-                          <span className="ml-1 text-sm font-medium text-gray-400">
-                            / {derivedStats.totalJobs}
-                          </span>
-                        )}
-                    </p>
-                  </div>
+                <div className="rounded-xl bg-black/50 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+                    Jobs completed
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {derivedStats.jobsCompleted ?? "—"}
+                    {derivedStats.totalJobs !== undefined &&
+                      derivedStats.totalJobs !== derivedStats.jobsCompleted &&
+                      derivedStats.totalJobs !== 0 && (
+                        <span className="ml-1 text-sm font-medium text-gray-400">
+                          / {derivedStats.totalJobs}
+                        </span>
+                      )}
+                  </p>
+                </div>
 
-                  {/* Avg per job */}
-                  <div className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Avg per job</p>
-                    <p className="text-xl font-semibold text-white">
-                      {derivedStats.avgPerJob}
-                    </p>
-                  </div>
+                <div className="rounded-xl bg-black/50 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+                    Avg per job
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {derivedStats.avgPerJob}
+                  </p>
+                </div>
 
-                  {/* Started */}
-                  <div className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Started</p>
-                    <p className="text-sm text-gray-200">
-                      {derivedStats.startLabel ?? "—"}
-                    </p>
-                  </div>
+                <div className="rounded-xl bg-black/50 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+                    Started
+                  </p>
+                  <p className="mt-2 text-sm text-gray-300">
+                    {derivedStats.startLabel ?? "—"}
+                  </p>
+                </div>
 
-                  {/* Wrapped up */}
-                  <div className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Wrapped up</p>
-                    <p className="text-sm text-gray-200">
-                      {derivedStats.endLabel ?? "—"}
-                    </p>
-                  </div>
+                <div className="rounded-xl bg-black/50 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+                    Wrapped up
+                  </p>
+                  <p className="mt-2 text-sm text-gray-300">
+                    {derivedStats.endLabel ?? "—"}
+                  </p>
+                </div>
 
-                  {/* Next Run */}
-                  <div className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Next Run</p>
-                    <p className="text-xl font-semibold text-white">
-                      {assignmentStatus === "loading"
-                        ? "Loading…"
-                        : assignmentStatus === "error"
-                        ? assignmentError
-                        : nextAssignment
-                        ? nextAssignment.day === "Today"
-                          ? `${nextAssignment.totalJobs} job${nextAssignment.totalJobs === 1 ? "" : "s"} left today`
-                          : `${nextAssignment.totalJobs} job${
-                              nextAssignment.totalJobs === 1 ? "" : "s"
-                            } on ${nextAssignment.day}, ${new Date().toLocaleDateString(undefined, {
-                              month: "short",
-                              day: "numeric",
-                            })}`
-                        : "—"}
-                    </p>
-                  </div>
+                <div className="rounded-xl bg-black/50 p-4 sm:col-span-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">
+                    Next run
+                  </p>
+                  <p className="mt-2 text-lg font-semibold text-white">
+                    {assignmentStatus === "loading"
+                      ? "Loading…"
+                      : assignmentStatus === "error"
+                      ? assignmentError
+                      : nextAssignment
+                      ? nextAssignment.day === "Today"
+                        ? `${nextAssignment.totalJobs} job${nextAssignment.totalJobs === 1 ? "" : "s"} left today`
+                        : `${nextAssignment.totalJobs} job${
+                            nextAssignment.totalJobs === 1 ? "" : "s"
+                          } on ${nextAssignment.day}, ${new Date().toLocaleDateString(undefined, {
+                            month: "short",
+                            day: "numeric",
+                          })}`
+                      : "—"}
+                  </p>
                 </div>
               </div>
-            )}
-          </section>
-        </div>
+            </div>
+          )}
+        </section>
       </div>
 
-      {/* Fixed footer button */}
-      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-10">
-        <div className="w-full bg-black/95 p-6 backdrop-blur">
-          <button
-            type="button"
-            onClick={() => router.push("/staff/run")}
-            className="pointer-events-auto w-full rounded-lg bg-[#ff5757] px-4 py-3 font-bold text-white transition hover:opacity-90"
-          >
-            End Run
-          </button>
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-20">
+        <div className="bg-black">
+          <div className="mx-auto w-full max-w-xl px-6 pb-6 pt-4">
+            <div className="relative">
+              <div
+                className="absolute left-0 top-0 w-screen bg-[#ff5757]"
+                style={{ height: "2px" }}
+              />
+              <button
+                type="button"
+                onClick={() => router.push("/staff/run")}
+                className="pointer-events-auto w-full rounded-lg bg-[#ff5757] px-4 py-3 font-bold text-white transition hover:opacity-90"
+              >
+                End Run
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -400,7 +419,7 @@ function CompletedRunContent() {
 export default function CompletedRunPage() {
   return (
     <MapSettingsProvider>
-      <div className="relative min-h-screen overflow-y-auto bg-black text-white pb-6">
+      <div className="relative min-h-screen bg-black text-white">
         <SettingsDrawer />
         <CompletedRunContent />
       </div>


### PR DESCRIPTION
## Summary
- refresh the proof workflow with route-themed styling, static quick reference guidance, and simplified bin cards
- restyle the completed run summary with a flat black backdrop, accent header, and stat cards that mirror the route page aesthetic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5d95abc148332bc6a97961ad302ad