### PR TITLE
Add admin console for managing clients and schedules

### DIFF
--- a/app/ops/admin/AdminConsole.tsx
+++ b/app/ops/admin/AdminConsole.tsx
@@ -1,0 +1,480 @@
+// app/ops/admin/AdminConsole.tsx
+'use client'
+
+import { useMemo, type ReactNode } from 'react'
+import { useFormState, useFormStatus } from 'react-dom'
+import {
+  assignWorkerAction,
+  createClientAction,
+  createPropertyAction,
+  createScheduleAction,
+  initialActionState,
+  type ActionState,
+} from './actions'
+
+type ClientAccount = {
+  id: string
+  name: string
+  contact_email?: string | null
+  contact_phone?: string | null
+}
+
+type PropertyRecord = {
+  id: string
+  account_id: string | null
+  client_name: string | null
+  address: string | null
+  collection_day: string | null
+  put_bins_out: string | null
+  assigned_to: string | null
+}
+
+type ScheduleRecord = {
+  id: string
+  property_id: string
+  out_weekdays: (number | string)[] | null
+  in_weekdays: (number | string)[] | null
+}
+
+type WorkerRecord = {
+  user_id: string
+  full_name: string | null
+  role: string | null
+}
+
+const WEEKDAYS = [
+  { value: 1, label: 'Mon' },
+  { value: 2, label: 'Tue' },
+  { value: 3, label: 'Wed' },
+  { value: 4, label: 'Thu' },
+  { value: 5, label: 'Fri' },
+  { value: 6, label: 'Sat' },
+  { value: 7, label: 'Sun' },
+]
+
+function SectionHeading({ title, description }: { title: string; description?: string }) {
+  return (
+    <header className="space-y-1">
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+      {description ? (
+        <p className="text-sm text-white/60">{description}</p>
+      ) : null}
+    </header>
+  )
+}
+
+function FormStatusMessage({ state }: { state: ActionState }) {
+  if (!state.message) return null
+  return (
+    <p
+      className={`text-sm ${state.ok ? 'text-emerald-400' : 'text-red-400'}`}
+      role="status"
+      aria-live="polite"
+    >
+      {state.message}
+    </p>
+  )
+}
+
+function SubmitButton({ label }: { label: string }) {
+  const status = useFormStatus()
+  return (
+    <button
+      type="submit"
+      className="rounded-md bg-binbird-red px-4 py-2 text-sm font-medium text-white transition hover:bg-binbird-red/90 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={status.pending}
+    >
+      {status.pending ? 'Saving…' : label}
+    </button>
+  )
+}
+
+function InfoList({ title, items }: { title: string; items: ReactNode[] }) {
+  if (!items.length) return null
+  return (
+    <section className="rounded-lg border border-white/10 bg-white/[0.02] p-4">
+      <h4 className="text-sm font-semibold uppercase tracking-wide text-white/50">{title}</h4>
+      <ul className="mt-2 space-y-1 text-sm text-white/80">
+        {items.map((item, index) => (
+          <li key={index} className="rounded-md bg-white/5 px-3 py-2">
+            {item}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+type AdminConsoleProps = {
+  clients: ClientAccount[]
+  properties: PropertyRecord[]
+  schedules: ScheduleRecord[]
+  workers: WorkerRecord[]
+  errors: string[]
+}
+
+export function AdminConsole({ clients, properties, schedules, workers, errors }: AdminConsoleProps) {
+  const [clientState, clientAction] = useFormState(createClientAction, initialActionState)
+  const [propertyState, propertyAction] = useFormState(createPropertyAction, initialActionState)
+  const [scheduleState, scheduleAction] = useFormState(createScheduleAction, initialActionState)
+  const [assignState, assignAction] = useFormState(assignWorkerAction, initialActionState)
+
+  const scheduleMap = useMemo(() => {
+    const map = new Map<string, ScheduleRecord>()
+    schedules.forEach((schedule) => {
+      map.set(schedule.property_id, schedule)
+    })
+    return map
+  }, [schedules])
+
+  const propertyOptions = useMemo(
+    () =>
+      properties.map((property) => ({
+        id: property.id,
+        label: `${property.client_name ?? 'Property'} — ${property.address ?? 'No address'}`,
+        accountId: property.account_id,
+        assignedTo: property.assigned_to,
+      })),
+    [properties],
+  )
+
+  const workersById = useMemo(() => {
+    const map = new Map<string, WorkerRecord>()
+    workers.forEach((worker) => {
+      if (worker.user_id) {
+        map.set(worker.user_id, worker)
+      }
+    })
+    return map
+  }, [workers])
+
+  const propertyInfoItems = propertyOptions.map((property) => {
+    const schedule = scheduleMap.get(property.id)
+    const assignedWorker = property.assignedTo ? workersById.get(property.assignedTo) : null
+    const formatDays = (values: (number | string)[] | null | undefined) =>
+      values && values.length
+        ? values
+            .map((value) => {
+              const numeric = typeof value === 'number' ? value : Number(value)
+              const label = WEEKDAYS.find((day) => day.value === numeric)?.label
+              return label ?? String(value)
+            })
+            .join(', ')
+        : '—'
+
+    return (
+      <div className="space-y-1" key={property.id}>
+        <p className="font-medium text-white">{property.label}</p>
+        <p className="text-xs text-white/50">
+          Client ID: <span className="font-mono">{property.accountId ?? 'Unknown'}</span>
+        </p>
+        <p className="text-xs text-white/50">
+          Assigned to: {assignedWorker?.full_name ?? 'Unassigned'}
+        </p>
+        <p className="text-xs text-white/50">
+          Put out: {schedule ? formatDays(schedule.out_weekdays ?? null) : '—'} | Bring in:{' '}
+          {schedule ? formatDays(schedule.in_weekdays ?? null) : '—'}
+        </p>
+      </div>
+    )
+  })
+
+  return (
+    <div className="space-y-10">
+      {errors.length ? (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
+          <p className="font-semibold">We hit a snag loading some data:</p>
+          <ul className="mt-2 list-disc pl-5">
+            {errors.map((error, index) => (
+              <li key={index}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <section className="rounded-lg border border-white/10 bg-white/[0.02] p-6">
+        <SectionHeading
+          title="Create client account"
+          description="Add a new client account so you can connect properties and generate tokens."
+        />
+        <form action={clientAction} className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="text-sm text-white/70">
+            Client name
+            <input
+              type="text"
+              name="name"
+              required
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="Acme Corp"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Contact email
+            <input
+              type="email"
+              name="contactEmail"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="ops@acme.com"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Contact phone
+            <input
+              type="tel"
+              name="contactPhone"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="+61 400 000 000"
+            />
+          </label>
+          <div className="flex items-end justify-end">
+            <SubmitButton label="Create client" />
+          </div>
+          <div className="md:col-span-2">
+            <FormStatusMessage state={clientState} />
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-white/10 bg-white/[0.02] p-6">
+        <SectionHeading
+          title="Add property"
+          description="Connect a new property to an account, configure basic service info, and optionally assign a crew member."
+        />
+        <form action={propertyAction} className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="text-sm text-white/70">
+            Client account
+            <select
+              name="accountId"
+              required
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              defaultValue=""
+            >
+              <option value="" disabled>
+                Select client…
+              </option>
+              {clients.map((client) => (
+                <option key={client.id} value={client.id}>
+                  {client.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm text-white/70">
+            Property name
+            <input
+              type="text"
+              name="clientName"
+              required
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="Penthouse - Collins St"
+            />
+          </label>
+          <label className="text-sm text-white/70 md:col-span-2">
+            Address
+            <input
+              type="text"
+              name="address"
+              required
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="123 Collins Street, Melbourne"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Put bins out day
+            <input
+              type="text"
+              name="putOutDay"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="Monday evening"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Collection day
+            <input
+              type="text"
+              name="collectionDay"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="Tuesday"
+            />
+          </label>
+          <label className="text-sm text-white/70 md:col-span-2">
+            Notes
+            <textarea
+              name="notes"
+              rows={3}
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="Gate code, bin room location, special instructions…"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Property email
+            <input
+              type="email"
+              name="email"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="manager@building.com"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Monthly price (AUD)
+            <input
+              type="number"
+              name="pricePerMonth"
+              min={0}
+              step="0.01"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              placeholder="149"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Latitude
+            <input
+              type="number"
+              name="latitude"
+              step="any"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            />
+          </label>
+          <label className="text-sm text-white/70">
+            Longitude
+            <input
+              type="number"
+              name="longitude"
+              step="any"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            />
+          </label>
+          <label className="text-sm text-white/70 md:col-span-2">
+            Assign worker
+            <select
+              name="assignedTo"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              defaultValue=""
+            >
+              <option value="">Unassigned</option>
+              {workers.map((worker) => (
+                <option key={worker.user_id} value={worker.user_id}>
+                  {worker.full_name ?? worker.user_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="md:col-span-2 flex items-center justify-end">
+            <SubmitButton label="Create property" />
+          </div>
+          <div className="md:col-span-2">
+            <FormStatusMessage state={propertyState} />
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-white/10 bg-white/[0.02] p-6">
+        <SectionHeading
+          title="Manage bin schedules"
+          description="Set which days crews put bins out and bring them back for each property."
+        />
+        <form action={scheduleAction} className="mt-4 space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="text-sm text-white/70">
+              Property
+              <select
+                name="propertyId"
+                required
+                className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+                defaultValue=""
+              >
+                <option value="" disabled>
+                  Select property…
+                </option>
+                {propertyOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="space-y-2 text-sm text-white/70">
+              <span>Put bins out</span>
+              <div className="flex flex-wrap gap-3">
+                {WEEKDAYS.map((day) => (
+                  <label key={day.value} className="flex items-center gap-2 rounded-md border border-white/10 bg-black/30 px-3 py-2">
+                    <input type="checkbox" name="outWeekdays" value={day.value} className="accent-binbird-red" />
+                    <span>{day.label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2 text-sm text-white/70">
+              <span>Bring bins in</span>
+              <div className="flex flex-wrap gap-3">
+                {WEEKDAYS.map((day) => (
+                  <label key={day.value} className="flex items-center gap-2 rounded-md border border-white/10 bg-black/30 px-3 py-2">
+                    <input type="checkbox" name="inWeekdays" value={day.value} className="accent-binbird-red" />
+                    <span>{day.label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center justify-end">
+            <SubmitButton label="Save schedule" />
+          </div>
+          <FormStatusMessage state={scheduleState} />
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-white/10 bg-white/[0.02] p-6">
+        <SectionHeading
+          title="Assign worker"
+          description="Update who is responsible for a property."
+        />
+        <form action={assignAction} className="mt-4 grid gap-4 md:grid-cols-2">
+          <label className="text-sm text-white/70">
+            Property
+            <select
+              name="propertyId"
+              required
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              defaultValue=""
+            >
+              <option value="" disabled>
+                Select property…
+              </option>
+              {propertyOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm text-white/70">
+            Worker
+            <select
+              name="workerId"
+              className="mt-1 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              defaultValue=""
+            >
+              <option value="">Unassigned</option>
+              {workers.map((worker) => (
+                <option key={worker.user_id} value={worker.user_id}>
+                  {worker.full_name ?? worker.user_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="md:col-span-2 flex items-center justify-end">
+            <SubmitButton label="Update assignment" />
+          </div>
+          <div className="md:col-span-2">
+            <FormStatusMessage state={assignState} />
+          </div>
+        </form>
+      </section>
+
+      <InfoList title="Current properties" items={propertyInfoItems} />
+    </div>
+  )
+}
+
+export type { ClientAccount, PropertyRecord, ScheduleRecord, WorkerRecord }
+

--- a/app/ops/admin/actions.ts
+++ b/app/ops/admin/actions.ts
@@ -1,0 +1,310 @@
+// app/ops/admin/actions.ts
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { supabaseServer } from '@/lib/supabaseServer'
+
+export type ActionState = {
+  ok: boolean
+  message: string
+}
+
+const DEFAULT_ERROR: ActionState = {
+  ok: false,
+  message: 'Something went wrong. Please try again.',
+}
+
+function handleError(message?: string): ActionState {
+  return {
+    ok: false,
+    message: message ?? DEFAULT_ERROR.message,
+  }
+}
+
+async function requireUser() {
+  const sb = supabaseServer()
+  const {
+    data: { user },
+    error,
+  } = await sb.auth.getUser()
+
+  if (error || !user) {
+    throw new Error('You must be signed in to perform this action.')
+  }
+
+  return { sb, user }
+}
+
+const createClientSchema = z.object({
+  name: z.string().min(1, 'Client name is required.'),
+  contactEmail: z
+    .string()
+    .email('Enter a valid email address.')
+    .optional()
+    .or(z.literal('')),
+  contactPhone: z
+    .string()
+    .trim()
+    .optional()
+    .or(z.literal('')),
+})
+
+export async function createClientAction(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  let sb
+  try {
+    ;({ sb } = await requireUser())
+  } catch (error) {
+    return handleError(error instanceof Error ? error.message : undefined)
+  }
+
+  const payload = {
+    name: formData.get('name'),
+    contactEmail: formData.get('contactEmail'),
+    contactPhone: formData.get('contactPhone'),
+  }
+
+  const parsed = createClientSchema.safeParse(payload)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    return handleError(issue?.message)
+  }
+
+  const data = parsed.data
+  const insertPayload = {
+    name: data.name,
+    contact_email: data.contactEmail?.length ? data.contactEmail : null,
+    contact_phone: data.contactPhone?.length ? data.contactPhone : null,
+  }
+
+  const { error } = await sb.from('client_accounts').insert(insertPayload)
+
+  if (error) {
+    return handleError(error.message)
+  }
+
+  revalidatePath('/ops/admin')
+  return {
+    ok: true,
+    message: 'Client created successfully.',
+  }
+}
+
+const createPropertySchema = z.object({
+  accountId: z.string().min(1, 'Select a client account.'),
+  clientName: z
+    .string()
+    .trim()
+    .min(1, 'Property name is required.'),
+  address: z.string().trim().min(1, 'Street address is required.'),
+  collectionDay: z.string().optional().or(z.literal('')),
+  putOutDay: z.string().optional().or(z.literal('')),
+  notes: z.string().optional().or(z.literal('')),
+  email: z.string().email('Enter a valid email.').optional().or(z.literal('')),
+  pricePerMonth: z.string().optional().or(z.literal('')),
+  latitude: z.string().optional().or(z.literal('')),
+  longitude: z.string().optional().or(z.literal('')),
+  assignedTo: z.string().optional().or(z.literal('')),
+})
+
+export async function createPropertyAction(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  let sb
+  try {
+    ;({ sb } = await requireUser())
+  } catch (error) {
+    return handleError(error instanceof Error ? error.message : undefined)
+  }
+
+  const payload = {
+    accountId: formData.get('accountId'),
+    clientName: formData.get('clientName'),
+    address: formData.get('address'),
+    collectionDay: formData.get('collectionDay'),
+    putOutDay: formData.get('putOutDay'),
+    notes: formData.get('notes'),
+    email: formData.get('email'),
+    pricePerMonth: formData.get('pricePerMonth'),
+    latitude: formData.get('latitude'),
+    longitude: formData.get('longitude'),
+    assignedTo: formData.get('assignedTo'),
+  }
+
+  const parsed = createPropertySchema.safeParse(payload)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    return handleError(issue?.message)
+  }
+
+  const data = parsed.data
+  let pricePerMonth: number | null = null
+  if (data.pricePerMonth && data.pricePerMonth.length) {
+    const parsedPrice = Number(data.pricePerMonth)
+    if (!Number.isFinite(parsedPrice) || parsedPrice < 0) {
+      return handleError('Monthly price must be a positive number.')
+    }
+    pricePerMonth = parsedPrice
+  }
+
+  let latitude: number | null = null
+  if (data.latitude && data.latitude.length) {
+    const parsedLat = Number(data.latitude)
+    if (!Number.isFinite(parsedLat)) {
+      return handleError('Latitude must be a valid number.')
+    }
+    latitude = parsedLat
+  }
+
+  let longitude: number | null = null
+  if (data.longitude && data.longitude.length) {
+    const parsedLng = Number(data.longitude)
+    if (!Number.isFinite(parsedLng)) {
+      return handleError('Longitude must be a valid number.')
+    }
+    longitude = parsedLng
+  }
+
+  const latLng =
+    latitude !== null && longitude !== null ? `${latitude},${longitude}` : null
+
+  const insertPayload = {
+    account_id: data.accountId,
+    client_name: data.clientName,
+    address: data.address,
+    collection_day: data.collectionDay?.length ? data.collectionDay : null,
+    put_bins_out: data.putOutDay?.length ? data.putOutDay : null,
+    notes: data.notes?.length ? data.notes : null,
+    email: data.email?.length ? data.email : null,
+    price_per_month: pricePerMonth,
+    lat_lng: latLng,
+    assigned_to: data.assignedTo?.length ? data.assignedTo : null,
+  }
+
+  const { error } = await sb.from('property').insert(insertPayload)
+
+  if (error) {
+    return handleError(error.message)
+  }
+
+  revalidatePath('/ops/admin')
+  return {
+    ok: true,
+    message: 'Property created successfully.',
+  }
+}
+
+const WEEKDAY_SCHEMA = z
+  .array(z.coerce.number().int().min(1).max(7))
+  .optional()
+  .transform((values) => (values && values.length ? values : null))
+
+const createScheduleSchema = z.object({
+  propertyId: z.string().min(1, 'Select a property.'),
+  outWeekdays: WEEKDAY_SCHEMA,
+  inWeekdays: WEEKDAY_SCHEMA,
+})
+
+export async function createScheduleAction(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  let sb
+  try {
+    ;({ sb } = await requireUser())
+  } catch (error) {
+    return handleError(error instanceof Error ? error.message : undefined)
+  }
+
+  const payload = {
+    propertyId: formData.get('propertyId'),
+    outWeekdays: formData.getAll('outWeekdays'),
+    inWeekdays: formData.getAll('inWeekdays'),
+  }
+
+  const parsed = createScheduleSchema.safeParse(payload)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    return handleError(issue?.message)
+  }
+
+  const { propertyId, outWeekdays, inWeekdays } = parsed.data
+
+  const { error } = await sb
+    .from('schedule')
+    .upsert(
+      {
+        property_id: propertyId,
+        out_weekdays: outWeekdays,
+        in_weekdays: inWeekdays,
+      },
+      { onConflict: 'property_id' },
+    )
+
+  if (error) {
+    return handleError(error.message)
+  }
+
+  revalidatePath('/ops/admin')
+  return {
+    ok: true,
+    message: 'Bin schedule saved successfully.',
+  }
+}
+
+const assignWorkerSchema = z.object({
+  propertyId: z.string().min(1, 'Select a property.'),
+  workerId: z
+    .string()
+    .optional()
+    .or(z.literal('')),
+})
+
+export async function assignWorkerAction(
+  _prevState: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  let sb
+  try {
+    ;({ sb } = await requireUser())
+  } catch (error) {
+    return handleError(error instanceof Error ? error.message : undefined)
+  }
+
+  const payload = {
+    propertyId: formData.get('propertyId'),
+    workerId: formData.get('workerId'),
+  }
+
+  const parsed = assignWorkerSchema.safeParse(payload)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    return handleError(issue?.message)
+  }
+
+  const { propertyId, workerId } = parsed.data
+
+  const { error } = await sb
+    .from('property')
+    .update({ assigned_to: workerId?.length ? workerId : null })
+    .eq('id', propertyId)
+
+  if (error) {
+    return handleError(error.message)
+  }
+
+  revalidatePath('/ops/admin')
+  return {
+    ok: true,
+    message: workerId?.length ? 'Worker assigned to property.' : 'Property unassigned successfully.',
+  }
+}
+
+export const initialActionState: ActionState = {
+  ok: false,
+  message: '',
+}

--- a/app/ops/admin/page.tsx
+++ b/app/ops/admin/page.tsx
@@ -3,10 +3,13 @@ import BackButton from '@/components/UI/BackButton'
 import { supabaseServer } from '@/lib/supabaseServer'
 import { AdminConsole, type ClientAccount, type PropertyRecord, type ScheduleRecord, type WorkerRecord } from './AdminConsole'
 
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
 export default async function AdminPage() {
   const sb = supabaseServer()
 
-  const [userResult, clientsResult, propertiesResult, schedulesResult, workersResult] = await Promise.all([
+  const [userResult, clientsResult, propertiesResult, schedulesResult, workersResult] = await Promise.allSettled([
     sb.auth.getUser(),
     sb
       .from('client_accounts')
@@ -24,27 +27,55 @@ export default async function AdminPage() {
       .order('full_name', { ascending: true }),
   ])
 
-  const {
-    data: { user },
-  } = userResult
+  const user =
+    userResult.status === 'fulfilled'
+      ? userResult.value.data.user
+      : null
 
   if (!user) {
+    const message =
+      userResult.status === 'rejected'
+        ? 'Unable to check your session. Please try again.'
+        : 'You need to sign in with an operations account to manage clients and properties.'
+
     return (
       <div className="container">
         <BackButton />
         <h2 className="text-xl font-semibold">Admin access required</h2>
-        <p className="mt-2 text-white/70">
-          You need to sign in with an operations account to manage clients and properties.
-        </p>
+        <p className="mt-2 text-white/70">{message}</p>
       </div>
     )
   }
 
   const errors: string[] = []
-  if (clientsResult.error) errors.push(`Clients: ${clientsResult.error.message}`)
-  if (propertiesResult.error) errors.push(`Properties: ${propertiesResult.error.message}`)
-  if (schedulesResult.error) errors.push(`Schedules: ${schedulesResult.error.message}`)
-  if (workersResult.error) errors.push(`Workers: ${workersResult.error.message}`)
+  const clientsData = clientsResult.status === 'fulfilled' ? clientsResult.value : null
+  const propertiesData = propertiesResult.status === 'fulfilled' ? propertiesResult.value : null
+  const schedulesData = schedulesResult.status === 'fulfilled' ? schedulesResult.value : null
+  const workersData = workersResult.status === 'fulfilled' ? workersResult.value : null
+
+  if (clientsResult.status === 'rejected') {
+    errors.push('Clients: Failed to load client accounts.')
+  } else if (clientsData?.error) {
+    errors.push(`Clients: ${clientsData.error.message}`)
+  }
+
+  if (propertiesResult.status === 'rejected') {
+    errors.push('Properties: Failed to load properties.')
+  } else if (propertiesData?.error) {
+    errors.push(`Properties: ${propertiesData.error.message}`)
+  }
+
+  if (schedulesResult.status === 'rejected') {
+    errors.push('Schedules: Failed to load schedules.')
+  } else if (schedulesData?.error) {
+    errors.push(`Schedules: ${schedulesData.error.message}`)
+  }
+
+  if (workersResult.status === 'rejected') {
+    errors.push('Workers: Failed to load worker roster.')
+  } else if (workersData?.error) {
+    errors.push(`Workers: ${workersData.error.message}`)
+  }
 
   return (
     <div className="container space-y-6 py-6">
@@ -58,10 +89,10 @@ export default async function AdminPage() {
       </header>
 
       <AdminConsole
-        clients={(clientsResult.data ?? []) as ClientAccount[]}
-        properties={(propertiesResult.data ?? []) as PropertyRecord[]}
-        schedules={(schedulesResult.data ?? []) as ScheduleRecord[]}
-        workers={(workersResult.data ?? []) as WorkerRecord[]}
+        clients={(clientsData?.data ?? []) as ClientAccount[]}
+        properties={(propertiesData?.data ?? []) as PropertyRecord[]}
+        schedules={(schedulesData?.data ?? []) as ScheduleRecord[]}
+        workers={(workersData?.data ?? []) as WorkerRecord[]}
         errors={errors}
       />
     </div>

--- a/app/ops/admin/page.tsx
+++ b/app/ops/admin/page.tsx
@@ -1,0 +1,70 @@
+// app/ops/admin/page.tsx
+import BackButton from '@/components/UI/BackButton'
+import { supabaseServer } from '@/lib/supabaseServer'
+import { AdminConsole, type ClientAccount, type PropertyRecord, type ScheduleRecord, type WorkerRecord } from './AdminConsole'
+
+export default async function AdminPage() {
+  const sb = supabaseServer()
+
+  const [userResult, clientsResult, propertiesResult, schedulesResult, workersResult] = await Promise.all([
+    sb.auth.getUser(),
+    sb
+      .from('client_accounts')
+      .select('id, name, contact_email, contact_phone')
+      .order('name', { ascending: true }),
+    sb
+      .from('property')
+      .select('id, account_id, client_name, address, collection_day, put_bins_out, assigned_to')
+      .order('client_name', { ascending: true }),
+    sb.from('schedule').select('id, property_id, out_weekdays, in_weekdays'),
+    sb
+      .from('user_profile')
+      .select('user_id, full_name, role')
+      .in('role', ['staff', 'admin'])
+      .order('full_name', { ascending: true }),
+  ])
+
+  const {
+    data: { user },
+  } = userResult
+
+  if (!user) {
+    return (
+      <div className="container">
+        <BackButton />
+        <h2 className="text-xl font-semibold">Admin access required</h2>
+        <p className="mt-2 text-white/70">
+          You need to sign in with an operations account to manage clients and properties.
+        </p>
+      </div>
+    )
+  }
+
+  const errors: string[] = []
+  if (clientsResult.error) errors.push(`Clients: ${clientsResult.error.message}`)
+  if (propertiesResult.error) errors.push(`Properties: ${propertiesResult.error.message}`)
+  if (schedulesResult.error) errors.push(`Schedules: ${schedulesResult.error.message}`)
+  if (workersResult.error) errors.push(`Workers: ${workersResult.error.message}`)
+
+  return (
+    <div className="container space-y-6 py-6">
+      <BackButton />
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold text-white">Admin control centre</h1>
+        <p className="text-sm text-white/70">
+          Create clients, connect properties, configure bin schedules, and keep your crew assignments up to date — all from one
+          place.
+        </p>
+      </header>
+
+      <AdminConsole
+        clients={(clientsResult.data ?? []) as ClientAccount[]}
+        properties={(propertiesResult.data ?? []) as PropertyRecord[]}
+        schedules={(schedulesResult.data ?? []) as ScheduleRecord[]}
+        workers={(workersResult.data ?? []) as WorkerRecord[]}
+        errors={errors}
+      />
+    </div>
+  )
+}
+

--- a/app/ops/page.tsx
+++ b/app/ops/page.tsx
@@ -28,6 +28,9 @@ export default async function Ops() {
         <li>
           <a href="/ops/dashboard">Dashboard</a>
         </li>
+        <li>
+          <a href="/ops/admin">Admin Control</a>
+        </li>
       </ul>
     </div>
   )


### PR DESCRIPTION
## Summary
- add an ops admin control centre with forms for managing clients, properties, schedules, and crew assignments
- implement Supabase-backed server actions with validation and UI feedback for each administrative workflow
- surface the admin console from the existing ops landing page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8c1d913948332b673e22dbcf07f62