### PR TITLE
Add portal picker to main dashboard

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -5,11 +5,19 @@ import { supabase } from '@/lib/supabaseClient'
 import GuestDashboard from './GuestDashboard'
 import StaffDashboard from './StaffDashboard'
 import AdminDashboard from './AdminDashboard'
-import PortalPicker from './PortalPicker'
+import PortalPicker, { type PortalRole } from './PortalPicker'
 
 export default function Dashboard() {
   const [loading, setLoading] = useState(true)
-  const [role, setRole] = useState<string | null>(null)
+  const [role, setRole] = useState<PortalRole | null>(null)
+
+  const normalizeRole = (value: string | null | undefined): PortalRole => {
+    if (value === 'client' || value === 'staff' || value === 'admin') {
+      return value
+    }
+
+    return 'staff'
+  }
 
   useEffect(() => {
     async function load() {
@@ -26,7 +34,7 @@ export default function Dashboard() {
         .eq('id', user.id)
         .maybeSingle()
 
-      setRole(profile?.role || 'staff')
+      setRole(normalizeRole(profile?.role))
       setLoading(false)
     }
     load()

--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@/lib/supabaseClient'
 import GuestDashboard from './GuestDashboard'
 import StaffDashboard from './StaffDashboard'
 import AdminDashboard from './AdminDashboard'
+import PortalPicker from './PortalPicker'
 
 export default function Dashboard() {
   const [loading, setLoading] = useState(true)
@@ -39,14 +40,17 @@ export default function Dashboard() {
     )
   }
 
+  if (role === 'guest') {
+    return <GuestDashboard />
+  }
+
   return (
     <div className="flex flex-col min-h-screen bg-black text-white">
       {/* Sticky header */}
       <header className="sticky top-0 z-10 bg-black border-b border-white/10 px-4 py-3 flex items-center justify-between">
         <h1 className="text-lg font-bold text-[#ff5757]">BinBird</h1>
 
-        {/* Show sign out only if logged in */}
-        {(role === 'staff' || role === 'admin') && (
+        {(role === 'staff' || role === 'admin' || role === 'client') && (
           <button
             onClick={async () => {
               await supabase.auth.signOut()
@@ -60,8 +64,8 @@ export default function Dashboard() {
       </header>
 
       {/* Content */}
-      <main className="flex-1 overflow-y-auto px-6 py-8">
-        {role === 'guest' && <GuestDashboard />}
+      <main className="flex-1 overflow-y-auto px-6 py-8 space-y-10">
+        <PortalPicker role={role} />
         {role === 'admin' && <AdminDashboard />}
         {role === 'staff' && <StaffDashboard />}
       </main>

--- a/components/Dashboard/PortalPicker.tsx
+++ b/components/Dashboard/PortalPicker.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import Link from 'next/link'
+import clsx from 'clsx'
+import type { LucideIcon } from 'lucide-react'
+import { Users, BriefcaseBusiness, ShieldCheck } from 'lucide-react'
+
+type PortalRole = 'guest' | 'client' | 'staff' | 'admin' | null
+type AccessRole = Exclude<PortalRole, 'guest' | null>
+
+type PortalOption = {
+  id: string
+  title: string
+  description: string
+  href: string
+  icon: LucideIcon
+  allowedRoles: AccessRole[]
+  lockedLabel: string
+}
+
+const portalOptions: PortalOption[] = [
+  {
+    id: 'client',
+    title: 'Client Portal',
+    description: 'Track scheduled services, review visit logs, and download proofs for your properties.',
+    href: '/client',
+    icon: Users,
+    allowedRoles: ['client', 'admin'],
+    lockedLabel: 'Requires client access',
+  },
+  {
+    id: 'staff',
+    title: 'Staff Portal',
+    description: 'Access routing tools, run management, and on-the-ground reporting utilities.',
+    href: '/ops',
+    icon: BriefcaseBusiness,
+    allowedRoles: ['staff', 'admin'],
+    lockedLabel: 'Requires staff access',
+  },
+  {
+    id: 'admin',
+    title: 'Admin Portal',
+    description: 'Manage users, clients, and system configuration with elevated permissions.',
+    href: '/admin',
+    icon: ShieldCheck,
+    allowedRoles: ['admin'],
+    lockedLabel: 'Requires admin access',
+  },
+]
+
+type PortalPickerProps = {
+  role: PortalRole
+}
+
+export default function PortalPicker({ role }: PortalPickerProps) {
+  const normalizedRole: PortalRole = role ?? 'guest'
+
+  const cards = portalOptions.map((portal) => {
+    const isAllowed = portal.allowedRoles.includes(normalizedRole as AccessRole)
+    const Icon = portal.icon
+
+    const cardContent = (
+      <article
+        className={clsx(
+          'relative flex h-full flex-col justify-between rounded-2xl border border-white/10 p-5 transition',
+          'bg-white/[0.06] text-white shadow-lg shadow-black/20 backdrop-blur',
+          isAllowed
+            ? 'hover:border-[#ff5757] hover:bg-white/[0.12] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#ff5757]'
+            : 'cursor-not-allowed opacity-50'
+        )}
+      >
+        <div className="flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-[#ff5757]/10 text-[#ff5757]">
+            <Icon className="h-6 w-6" />
+          </span>
+          <h3 className="text-lg font-semibold">{portal.title}</h3>
+        </div>
+        <p className="mt-4 text-sm leading-relaxed text-white/70">{portal.description}</p>
+        {!isAllowed && (
+          <p className="mt-6 text-xs font-medium uppercase tracking-wide text-white/40">
+            {portal.lockedLabel}
+          </p>
+        )}
+      </article>
+    )
+
+    if (!isAllowed) {
+      return (
+        <div key={portal.id} className="h-full">
+          {cardContent}
+        </div>
+      )
+    }
+
+    return (
+      <Link key={portal.id} href={portal.href} className="h-full focus:outline-none">
+        {cardContent}
+      </Link>
+    )
+  })
+
+  const hasVisibleCard = cards.some((card) => card !== null)
+  if (!hasVisibleCard) {
+    return null
+  }
+
+  return (
+    <section aria-labelledby="portal-picker-heading" className="w-full">
+      <div className="mb-6 flex flex-col gap-1">
+        <h2 id="portal-picker-heading" className="text-xl font-semibold text-white">
+          Choose a portal
+        </h2>
+        <p className="text-sm text-white/60">
+          Quickly jump into the experience that matches the task you need to accomplish.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">{cards}</div>
+    </section>
+  )
+}

--- a/components/Dashboard/PortalPicker.tsx
+++ b/components/Dashboard/PortalPicker.tsx
@@ -5,8 +5,8 @@ import clsx from 'clsx'
 import type { LucideIcon } from 'lucide-react'
 import { Users, BriefcaseBusiness, ShieldCheck } from 'lucide-react'
 
-type PortalRole = 'guest' | 'client' | 'staff' | 'admin' | null
-type AccessRole = Exclude<PortalRole, 'guest' | null>
+export type PortalRole = 'guest' | 'client' | 'staff' | 'admin'
+type AccessRole = Exclude<PortalRole, 'guest'>
 
 type PortalOption = {
   id: string
@@ -49,7 +49,7 @@ const portalOptions: PortalOption[] = [
 ]
 
 type PortalPickerProps = {
-  role: PortalRole
+  role: PortalRole | null
 }
 
 export default function PortalPicker({ role }: PortalPickerProps) {


### PR DESCRIPTION
## Summary
- add a reusable portal picker component that presents navigation cards for the client, staff, and admin areas
- integrate the portal picker into the home dashboard and expose sign-out for client accounts as well

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9039a1d68833285c9881800c2f248