### PR TITLE
Increase bottom padding on completed run page

### DIFF
--- a/app/staff/run/completed/page.tsx
+++ b/app/staff/run/completed/page.tsx
@@ -278,7 +278,7 @@ function CompletedRunContent() {
 
   return (
     <div className="relative flex min-h-full flex-col bg-black text-white">
-      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col px-6 pb-32 pt-8 sm:pt-12">
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col px-6 pb-48 pt-8 sm:pt-12">
         <header className="space-y-3 text-center sm:text-left">
           <h1 className="text-3xl font-extrabold tracking-tight text-[#ff5757]">
             Run Complete!


### PR DESCRIPTION
## Summary
- increase the bottom padding on the completed run view to keep the Next Run section above the fixed End Run button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9902cbe3c83329b8616fae4ee675b