### PR TITLE
Fix clients page to query client_list table

### DIFF
--- a/app/ops/clients/page.tsx
+++ b/app/ops/clients/page.tsx
@@ -2,14 +2,62 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 
+type ClientListRow = {
+  id: string
+  client_name: string | null
+  address: string | null
+  red_freq: string | null
+  red_flip: string | null
+  yellow_freq: string | null
+  yellow_flip: string | null
+  green_freq: string | null
+  green_flip: string | null
+}
+
+type TableRow = ClientListRow & { bins_this_week: string | null }
+
+const describeBinFrequency = (color: string, frequency: string | null, flip: string | null) => {
+  if (!frequency) return null
+  const base = `${color} (${frequency.toLowerCase()})`
+  if (frequency === 'Fortnightly' && flip === 'Yes') {
+    return `${base}, alternate weeks`
+  }
+  return base
+}
+
+const deriveBinsSummary = (row: ClientListRow): string | null => {
+  const entries = [
+    describeBinFrequency('Red', row.red_freq, row.red_flip),
+    describeBinFrequency('Yellow', row.yellow_freq, row.yellow_flip),
+    describeBinFrequency('Green', row.green_freq, row.green_flip),
+  ].filter(Boolean) as string[]
+
+  if (!entries.length) return null
+  return entries.join(', ')
+}
+
 export default function ClientsPage() {
-  const [rows, setRows] = useState<any[]>([])
+  const [rows, setRows] = useState<TableRow[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     async function load() {
-      const { data } = await supabase.from('client_list_view').select('*')
-      setRows(data || [])
+      const { data, error } = await supabase
+        .from('client_list')
+        .select(
+          `id, client_name, address, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip`,
+        )
+
+      if (error) {
+        console.warn('Failed to load clients', error)
+        setRows([])
+      } else {
+        const derived = (data ?? []).map((row) => ({
+          ...row,
+          bins_this_week: deriveBinsSummary(row),
+        }))
+        setRows(derived)
+      }
       setLoading(false)
     }
     load()
@@ -33,7 +81,7 @@ export default function ClientsPage() {
             <tr key={i}>
               <td className="p-2 border">{r.client_name}</td>
               <td className="p-2 border">{r.address}</td>
-              <td className="p-2 border">{r.bins_this_week}</td>
+              <td className="p-2 border">{r.bins_this_week ?? '–'}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- update the clients page to read from the `client_list` table now that the view is gone
- derive the bins summary client-side from the frequency columns returned by Supabase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a6f322b88332a56f8ab978e5cb81