### PR TITLE
Query ops clients from base table

### DIFF
--- a/app/ops/clients/page.tsx
+++ b/app/ops/clients/page.tsx
@@ -1,15 +1,83 @@
 'use client'
+
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabaseClient'
 
+type ClientListRow = {
+  id: string
+  client_name: string | null
+  company: string | null
+  address: string | null
+  red_freq: string | null
+  red_flip: string | null
+  yellow_freq: string | null
+  yellow_flip: string | null
+  green_freq: string | null
+  green_flip: string | null
+}
+
+type TableRow = {
+  id: string
+  name: string
+  address: string
+  binsThisWeek: string
+}
+
+const describeBinFrequency = (
+  color: string,
+  frequency: string | null,
+  flip: string | null,
+): string | null => {
+  if (!frequency) return null
+  const base = `${color} (${frequency.toLowerCase()})`
+  if (frequency === 'Fortnightly' && flip === 'Yes') {
+    return `${base}, alternate weeks`
+  }
+  return base
+}
+
+const deriveBinsThisWeek = (row: ClientListRow): string => {
+  const bins = [
+    describeBinFrequency('Red', row.red_freq, row.red_flip),
+    describeBinFrequency('Yellow', row.yellow_freq, row.yellow_flip),
+    describeBinFrequency('Green', row.green_freq, row.green_flip),
+  ].filter(Boolean) as string[]
+
+  if (!bins.length) {
+    return '—'
+  }
+
+  return bins.join(', ')
+}
+
+const deriveName = (row: ClientListRow): string =>
+  row.client_name?.trim() || row.company?.trim() || 'Unnamed client'
+
+const deriveAddress = (row: ClientListRow): string => row.address?.trim() || '—'
+
 export default function ClientsPage() {
-  const [rows, setRows] = useState<any[]>([])
+  const [rows, setRows] = useState<TableRow[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     async function load() {
-      const { data } = await supabase.from('client_list_view').select('*')
-      setRows(data || [])
+      const { data } = await supabase
+        .from('client_list')
+        .select(
+          'id, client_name, company, address, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip',
+        )
+
+      const formatted = (data ?? []).map((row) => {
+        const typed = row as ClientListRow
+        return {
+          id: typed.id,
+          name: deriveName(typed),
+          address: deriveAddress(typed),
+          binsThisWeek: deriveBinsThisWeek(typed),
+        }
+      })
+
+      setRows(formatted)
       setLoading(false)
     }
     load()
@@ -29,11 +97,11 @@ export default function ClientsPage() {
           </tr>
         </thead>
         <tbody>
-          {rows.map((r, i) => (
-            <tr key={i}>
-              <td className="p-2 border">{r.client_name}</td>
-              <td className="p-2 border">{r.address}</td>
-              <td className="p-2 border">{r.bins_this_week}</td>
+          {rows.map((row) => (
+            <tr key={row.id}>
+              <td className="p-2 border">{row.name}</td>
+              <td className="p-2 border">{row.address}</td>
+              <td className="p-2 border">{row.binsThisWeek}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- fetch client records for the ops clients page directly from the `client_list` table
- derive the display name, address fallback, and bins summary in the component instead of relying on the view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a83e20588332a4ae316600877cdb