### PR TITLE
Use account IDs for client portal data

### DIFF
--- a/app/ops/generate/page.tsx
+++ b/app/ops/generate/page.tsx
@@ -28,6 +28,7 @@ const DAY_ALIASES: Record<string, number> = {
 
 type ClientListRow = {
   id: string
+  account_id: string | null
   client_name: string | null
   company: string | null
   address: string | null
@@ -100,7 +101,7 @@ const describeBinFrequency = (color: string, frequency: string | null, flip: str
 }
 
 const deriveAccountId = (row: ClientListRow): string =>
-  row.client_name?.trim() || row.company?.trim() || row.id
+  row.account_id?.trim() || row.client_name?.trim() || row.company?.trim() || row.id
 
 const buildBinsSummary = (row: ClientListRow): string | null => {
   const bins = [
@@ -127,7 +128,7 @@ async function generateJobs() {
   const { data: clients, error: clientError } = await sb
     .from('client_list')
     .select(
-      `id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, lat_lng, photo_path, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip`,
+      `id, account_id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, lat_lng, photo_path, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip`,
     )
 
   if (clientError) {

--- a/app/ops/tokens/page.tsx
+++ b/app/ops/tokens/page.tsx
@@ -4,12 +4,13 @@ import { supabaseServer } from '@/lib/supabaseServer'
 
 type ClientListRow = {
   id: string
+  account_id: string | null
   client_name: string | null
   company: string | null
 }
 
 const deriveAccountId = (row: ClientListRow): string =>
-  row.client_name?.trim() || row.company?.trim() || row.id
+  row.account_id?.trim() || row.client_name?.trim() || row.company?.trim() || row.id
 
 const deriveAccountName = (row: ClientListRow): string =>
   row.company?.trim() || row.client_name?.trim() || 'Client Account'
@@ -19,7 +20,7 @@ export default async function TokensPage() {
 
   const { data: clientRows, error: clientError } = await sb
     .from('client_list')
-    .select('id, client_name, company')
+    .select('id, account_id, client_name, company')
 
   if (clientError) {
     return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,12 +6,13 @@ import { ACTIVE_RUN_COOKIE_NAME } from '@/lib/active-run-cookie'
 
 type ClientListRow = {
   id: string
+  account_id: string | null
   client_name: string | null
   company: string | null
 }
 
 const deriveAccountId = (row: ClientListRow): string =>
-  row.client_name?.trim() || row.company?.trim() || row.id
+  row.account_id?.trim() || row.client_name?.trim() || row.company?.trim() || row.id
 
 export async function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname
@@ -80,9 +81,14 @@ export async function middleware(req: NextRequest) {
   }
 
   const fetchClientRowsForToken = async (accountId: string): Promise<ClientListRow[]> => {
-    const selectColumns = 'id, client_name, company'
+    const selectColumns = 'id, account_id, client_name, company'
     const deduped = new Map<string, ClientListRow>()
-    const queryColumns: Array<keyof ClientListRow> = ['id', 'client_name', 'company']
+    const queryColumns: Array<keyof ClientListRow> = [
+      'account_id',
+      'id',
+      'client_name',
+      'company',
+    ]
 
     for (const column of queryColumns) {
       const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- surface account UUIDs from client_list when generating jobs and portal data
- filter client portal jobs/logs and middleware token checks by account_id with client_name fallback
- ensure job generation and staff tooling continue writing the shared account UUID into jobs and logs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9b2ba629083328ecb1bfbe9331085