### PR TITLE
Enforce account ID usage across client portal flows

### DIFF
--- a/app/ops/generate/page.tsx
+++ b/app/ops/generate/page.tsx
@@ -47,7 +47,7 @@ type ClientListRow = {
 }
 
 type NewJobRow = {
-  account_id: string | null
+  account_id: string
   property_id: string | null
   address: string
   lat: number | null
@@ -101,7 +101,10 @@ const describeBinFrequency = (color: string, frequency: string | null, flip: str
 }
 
 const deriveAccountId = (row: ClientListRow): string =>
-  row.account_id?.trim() || row.client_name?.trim() || row.company?.trim() || row.id
+  (row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.id)
+
+const deriveClientName = (row: ClientListRow): string =>
+  row.client_name?.trim() || row.company?.trim() || 'Client'
 
 const buildBinsSummary = (row: ClientListRow): string | null => {
   const bins = [
@@ -145,6 +148,7 @@ async function generateJobs() {
   const jobs: NewJobRow[] = []
   for (const client of rows) {
     const accountId = deriveAccountId(client)
+    const clientName = deriveClientName(client)
     const { lat, lng } = parseLatLng(client.lat_lng)
     const bins = buildBinsSummary(client)
     const address = client.address?.trim() ?? ''
@@ -159,7 +163,7 @@ async function generateJobs() {
         job_type: 'put_out',
         bins,
         notes: client.notes,
-        client_name: accountId,
+        client_name: clientName,
         photo_path: client.photo_path,
         assigned_to: client.assigned_to,
         day_of_week: dayName,
@@ -177,7 +181,7 @@ async function generateJobs() {
         job_type: 'bring_in',
         bins,
         notes: client.notes,
-        client_name: accountId,
+        client_name: clientName,
         photo_path: client.photo_path,
         assigned_to: client.assigned_to,
         day_of_week: dayName,

--- a/app/ops/tokens/page.tsx
+++ b/app/ops/tokens/page.tsx
@@ -10,7 +10,7 @@ type ClientListRow = {
 }
 
 const deriveAccountId = (row: ClientListRow): string =>
-  row.account_id?.trim() || row.client_name?.trim() || row.company?.trim() || row.id
+  (row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.id)
 
 const deriveAccountName = (row: ClientListRow): string =>
   row.company?.trim() || row.client_name?.trim() || 'Client Account'

--- a/hooks/useRealtimeJobs.ts
+++ b/hooks/useRealtimeJobs.ts
@@ -35,16 +35,18 @@ export function useRealtimeJobs(accountId: string | null, onChange: (job: Job) =
       .channel(`jobs-client-${accountId}`)
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'jobs', filter: `client_name=eq.${accountId}` },
+        { event: '*', schema: 'public', table: 'jobs', filter: `account_id=eq.${accountId}` },
         (payload) => {
           const newJob = payload.new as any
           if (!newJob) return
           const scheduledAt = computeNextOccurrence(newJob.day_of_week ?? null)
           const bins = typeof newJob.bins === 'string' ? newJob.bins.split(',').map((value: string) => value.trim()) : []
+          const propertyId =
+            typeof newJob.property_id === 'string' && newJob.property_id.trim().length ? newJob.property_id.trim() : null
           const job: Job = {
             id: String(newJob.id),
             accountId,
-            propertyId: null,
+            propertyId,
             propertyName: newJob.address ?? 'Property',
             status: 'scheduled',
             scheduledAt,


### PR DESCRIPTION
## Summary
- ensure the ops job generator stores the canonical account_id while preserving client display names
- align client portal token validation, data fetching, and ops token listings with account_id-based lookups
- update client portal provider and realtime jobs hook to filter jobs/logs by account_id or property_id UUIDs instead of names

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d907b6594483328575fd67c64259af