### PR TITLE
Add admin client management screen

### DIFF
--- a/app/ops/manage/actions.ts
+++ b/app/ops/manage/actions.ts
@@ -1,0 +1,95 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import { supabaseServer } from '@/lib/supabaseServer'
+
+const updateClientSchema = z.object({
+  id: z.string().min(1, 'Client id is required.'),
+  address: z.string().max(500, 'Address is too long.').optional(),
+  collectionDay: z.string().max(120, 'Collection day is too long.').optional(),
+  putBinsOut: z.string().max(120, 'Put bins out value is too long.').optional(),
+  notes: z.string().max(2000, 'Notes are too long.').optional(),
+  assignedTo: z.string().min(1).nullable().optional(),
+})
+
+export type UpdateClientInput = z.infer<typeof updateClientSchema>
+
+export type UpdateClientResult =
+  | { success: true }
+  | { success: false; error: string; fieldErrors?: Record<string, string[]> }
+
+export async function updateClientProperty(payload: UpdateClientInput): Promise<UpdateClientResult> {
+  const normalized = {
+    ...payload,
+    address: payload.address?.trim(),
+    collectionDay: payload.collectionDay?.trim(),
+    putBinsOut: payload.putBinsOut?.trim(),
+    notes: payload.notes?.trim(),
+    assignedTo: payload.assignedTo ? payload.assignedTo.trim() : null,
+  }
+
+  const parsed = updateClientSchema.safeParse(normalized)
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: 'Please review the highlighted fields.',
+      fieldErrors: parsed.error.flatten().fieldErrors,
+    }
+  }
+
+  const { id, address, collectionDay, putBinsOut, notes, assignedTo } = parsed.data
+
+  const sb = supabaseServer()
+  const {
+    data: { user },
+    error: authError,
+  } = await sb.auth.getUser()
+
+  if (authError) {
+    console.error('Failed to resolve authenticated user when updating client', authError)
+    return { success: false, error: 'Unable to verify your session.' }
+  }
+
+  if (!user) {
+    return { success: false, error: 'You must be signed in to update clients.' }
+  }
+
+  const { data: profile, error: profileError } = await sb
+    .from('user_profile')
+    .select('role')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    console.error('Failed to load profile for user when updating client', profileError)
+    return { success: false, error: 'Unable to verify your permissions.' }
+  }
+
+  if (profile?.role !== 'admin') {
+    return { success: false, error: 'You do not have permission to update clients.' }
+  }
+
+  const updates: Record<string, string | null> = {
+    address: address && address.length ? address : null,
+    collection_day: collectionDay && collectionDay.length ? collectionDay : null,
+    put_bins_out: putBinsOut && putBinsOut.length ? putBinsOut : null,
+    notes: notes && notes.length ? notes : null,
+    assigned_to: assignedTo ?? null,
+  }
+
+  const { error: updateError } = await sb
+    .from('client_list')
+    .update(updates)
+    .eq('id', id)
+
+  if (updateError) {
+    console.error('Failed to update client property', updateError)
+    return { success: false, error: 'Failed to save changes to the client record.' }
+  }
+
+  revalidatePath('/ops/manage')
+
+  return { success: true }
+}

--- a/app/ops/manage/page.tsx
+++ b/app/ops/manage/page.tsx
@@ -1,0 +1,223 @@
+import BackButton from '@/components/UI/BackButton'
+import Card from '@/components/UI/Card'
+import AdminManagementTable, {
+  type AdminAccountGroup,
+  type AdminManagedProperty,
+  type AdminStaffMember,
+} from '@/components/ops/AdminManagementTable'
+import { supabaseServer } from '@/lib/supabaseServer'
+import { redirect } from 'next/navigation'
+import { Building2, ClipboardList, Users } from 'lucide-react'
+
+type ClientListRow = {
+  id: string
+  account_id: string | null
+  client_name: string | null
+  company: string | null
+  address: string | null
+  collection_day: string | null
+  put_bins_out: string | null
+  notes: string | null
+  assigned_to: string | null
+  red_freq: string | null
+  red_flip: string | null
+  yellow_freq: string | null
+  yellow_flip: string | null
+  green_freq: string | null
+  green_flip: string | null
+}
+
+type StaffRow = {
+  user_id: string
+  full_name: string | null
+  role: string | null
+}
+
+const describeBinFrequency = (color: string, frequency: string | null, flip: string | null): string | null => {
+  if (!frequency) return null
+  const base = `${color} (${frequency.toLowerCase()})`
+  if (frequency === 'Fortnightly' && flip === 'Yes') {
+    return `${base}, alternate weeks`
+  }
+  return base
+}
+
+const buildBinSummary = (row: ClientListRow): string | null => {
+  const entries = [
+    describeBinFrequency('Red', row.red_freq, row.red_flip),
+    describeBinFrequency('Yellow', row.yellow_freq, row.yellow_flip),
+    describeBinFrequency('Green', row.green_freq, row.green_flip),
+  ].filter(Boolean) as string[]
+
+  if (!entries.length) return null
+  return entries.join(', ')
+}
+
+const toNullable = (value: string | null | undefined): string | null => {
+  if (value === null || value === undefined) return null
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
+
+const deriveAccountId = (row: ClientListRow): string => toNullable(row.account_id) ?? row.id
+
+const deriveAccountName = (row: ClientListRow): string =>
+  toNullable(row.company) ?? toNullable(row.client_name) ?? 'Client account'
+
+const derivePropertyLabel = (row: ClientListRow): string => {
+  const clientName = toNullable(row.client_name)
+  if (clientName) return clientName
+
+  const address = toNullable(row.address)
+  if (address) {
+    const [firstLine] = address.split(',')
+    if (firstLine && firstLine.trim().length) {
+      return firstLine.trim()
+    }
+  }
+
+  return 'Property'
+}
+
+const mapClientRowsToAccounts = (rows: ClientListRow[]): AdminAccountGroup[] => {
+  const groups = new Map<string, AdminAccountGroup>()
+
+  rows.forEach((row) => {
+    const accountId = deriveAccountId(row)
+    const accountName = deriveAccountName(row)
+    const property: AdminManagedProperty = {
+      id: row.id,
+      accountId,
+      accountName,
+      propertyLabel: derivePropertyLabel(row),
+      clientName: toNullable(row.client_name),
+      companyName: toNullable(row.company),
+      address: toNullable(row.address) ?? '',
+      collectionDay: toNullable(row.collection_day),
+      putBinsOut: toNullable(row.put_bins_out),
+      notes: toNullable(row.notes),
+      assignedTo: toNullable(row.assigned_to),
+      binSummary: buildBinSummary(row),
+    }
+
+    const existing = groups.get(accountId)
+    if (existing) {
+      existing.properties.push(property)
+    } else {
+      groups.set(accountId, {
+        id: accountId,
+        name: accountName,
+        properties: [property],
+      })
+    }
+  })
+
+  const list = Array.from(groups.values())
+  list.forEach((group) => {
+    group.properties.sort((a, b) => a.propertyLabel.localeCompare(b.propertyLabel))
+  })
+
+  return list.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+const mapStaffRows = (rows: StaffRow[]): AdminStaffMember[] =>
+  rows
+    .filter((row): row is StaffRow & { user_id: string } => typeof row.user_id === 'string' && row.user_id.length > 0)
+    .map((row) => ({
+      id: row.user_id,
+      name: toNullable(row.full_name) ?? 'Unnamed staff member',
+      role: row.role ?? 'staff',
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+export default async function ManagePage() {
+  const sb = supabaseServer()
+  const {
+    data: { user },
+    error: userError,
+  } = await sb.auth.getUser()
+
+  if (userError) {
+    console.error('Failed to resolve user session for /ops/manage', userError)
+  }
+
+  if (!user) {
+    redirect('/auth')
+  }
+
+  const { data: profile, error: profileError } = await sb
+    .from('user_profile')
+    .select('role')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    console.error('Failed to load profile for manage screen', profileError)
+  }
+
+  if (profile?.role !== 'admin') {
+    redirect('/ops')
+  }
+
+  const [clientsResponse, staffResponse] = await Promise.all([
+    sb
+      .from('client_list')
+      .select(
+        `id, account_id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip`,
+      ),
+    sb
+      .from('user_profile')
+      .select('user_id, full_name, role')
+      .in('role', ['staff', 'admin']),
+  ])
+
+  const clientError = clientsResponse.error
+  if (clientError) {
+    console.error('Failed to load client list for manage screen', clientError)
+  }
+
+  const staffError = staffResponse.error
+  if (staffError) {
+    console.error('Failed to load staff directory for manage screen', staffError)
+  }
+
+  const clientRows = (clientsResponse.data ?? []) as ClientListRow[]
+  const staffRows = (staffResponse.data ?? []) as StaffRow[]
+
+  const accounts = clientError ? [] : mapClientRowsToAccounts(clientRows)
+  const staff = mapStaffRows(staffRows)
+
+  const totalProperties = accounts.reduce((acc, group) => acc + group.properties.length, 0)
+
+  return (
+    <div className="container space-y-6 py-6">
+      <BackButton />
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900">Client &amp; Staff Management</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Review client properties, adjust service details, and assign staff members to each property.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Card title={`Accounts: ${accounts.length}`} icon={Building2} />
+        <Card title={`Properties: ${totalProperties}`} icon={ClipboardList} />
+        <Card title={`Active staff: ${staff.length}`} icon={Users} />
+      </div>
+
+      {clientError ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          We could not load the client list. Please try again shortly.
+        </div>
+      ) : (
+        <AdminManagementTable accounts={accounts} staff={staff} />
+      )}
+
+      {staffError && !clientError && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+          Staff profiles could not be loaded. Existing assignments are shown, but new assignments may be limited to known users.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Dashboard/AdminDashboard.tsx
+++ b/components/Dashboard/AdminDashboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Header from '../UI/Header'
 import Card from '../UI/Card'
-import { Users, Cog, FileText, KeyRound, LogOut } from 'lucide-react'
+import { Users, Cog, FileText, KeyRound, LogOut, UserCog } from 'lucide-react'
 import { supabase } from '@/lib/supabaseClient'
 
 export default function AdminDashboard() {
@@ -16,6 +16,7 @@ export default function AdminDashboard() {
       <div className="grid gap-4 sm:grid-cols-2 mt-6">
         <Card title="Ops Console" icon={Cog} href="/ops" />
         <Card title="Client List" icon={Users} href="/ops/clients" />
+        <Card title="Manage Clients & Staff" icon={UserCog} href="/ops/manage" />
         <Card title="Logs & Proofs" icon={FileText} href="/ops/logs" />
         <Card title="Client Tokens" icon={KeyRound} href="/ops/tokens" />
         <Card title="Sign Out" icon={LogOut} onClick={signOut} />

--- a/components/ops/AdminManagementTable.tsx
+++ b/components/ops/AdminManagementTable.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import { useMemo, useState, useTransition } from 'react'
+import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
+import { updateClientProperty } from '@/app/ops/manage/actions'
+
+export type AdminStaffMember = {
+  id: string
+  name: string
+  role: string
+}
+
+export type AdminManagedProperty = {
+  id: string
+  accountId: string
+  accountName: string
+  propertyLabel: string
+  clientName: string | null
+  companyName: string | null
+  address: string
+  collectionDay: string | null
+  putBinsOut: string | null
+  notes: string | null
+  assignedTo: string | null
+  binSummary: string | null
+}
+
+export type AdminAccountGroup = {
+  id: string
+  name: string
+  properties: AdminManagedProperty[]
+}
+
+type SaveStatus = {
+  variant: 'success' | 'error'
+  message: string
+}
+
+type Props = {
+  accounts: AdminAccountGroup[]
+  staff: AdminStaffMember[]
+}
+
+function extractFieldError(fieldErrors: Record<string, string[]> | undefined): string | null {
+  if (!fieldErrors) return null
+  for (const key of Object.keys(fieldErrors)) {
+    const first = fieldErrors[key]?.[0]
+    if (first) return first
+  }
+  return null
+}
+
+export default function AdminManagementTable({ accounts, staff }: Props) {
+  const [statusByProperty, setStatusByProperty] = useState<Record<string, SaveStatus>>({})
+  const [pendingPropertyId, setPendingPropertyId] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const hasAccounts = accounts.length > 0
+
+  const staffOptions = useMemo(
+    () =>
+      [{ id: '', name: 'Unassigned', role: 'none' }, ...staff].map((member) => ({
+        value: member.id,
+        label: member.name.trim().length ? member.name : 'Unnamed staff member',
+        role: member.role,
+      })),
+    [staff],
+  )
+
+  const handleSubmit = (propertyId: string, formData: FormData) => {
+    const address = (formData.get('address') as string | null)?.trim() ?? ''
+    const collectionDay = (formData.get('collectionDay') as string | null)?.trim() ?? ''
+    const putBinsOut = (formData.get('putBinsOut') as string | null)?.trim() ?? ''
+    const notes = (formData.get('notes') as string | null)?.trim() ?? ''
+    const assignedToRaw = (formData.get('assignedTo') as string | null)?.trim() ?? ''
+    const assignedTo = assignedToRaw.length ? assignedToRaw : null
+
+    startTransition(async () => {
+      setPendingPropertyId(propertyId)
+      setStatusByProperty((prev) => {
+        const next = { ...prev }
+        delete next[propertyId]
+        return next
+      })
+
+      try {
+        const result = await updateClientProperty({
+          id: propertyId,
+          address,
+          collectionDay,
+          putBinsOut,
+          notes,
+          assignedTo,
+        })
+
+        if (!result.success) {
+          const fieldError = extractFieldError(result.fieldErrors)
+          setStatusByProperty((prev) => ({
+            ...prev,
+            [propertyId]: {
+              variant: 'error',
+              message: fieldError ?? result.error ?? 'Unable to save changes.',
+            },
+          }))
+        } else {
+          setStatusByProperty((prev) => ({
+            ...prev,
+            [propertyId]: {
+              variant: 'success',
+              message: 'Changes saved successfully.',
+            },
+          }))
+        }
+      } catch (error) {
+        console.error('Failed to update client property', error)
+        setStatusByProperty((prev) => ({
+          ...prev,
+          [propertyId]: {
+            variant: 'error',
+            message: 'Unexpected error occurred while saving changes.',
+          },
+        }))
+      } finally {
+        setPendingPropertyId(null)
+      }
+    })
+  }
+
+  if (!hasAccounts) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-600 shadow-sm">
+        There are no client properties to manage yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {accounts.map((account) => (
+        <section key={account.id} className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="flex flex-col gap-1 border-b border-gray-100 bg-gray-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="text-base font-semibold text-gray-900">{account.name}</h3>
+              <p className="text-xs text-gray-500">
+                {account.properties.length} {account.properties.length === 1 ? 'property' : 'properties'} linked to this account
+              </p>
+            </div>
+          </div>
+
+          <div className="divide-y divide-gray-100">
+            {account.properties.map((property) => {
+              const status = statusByProperty[property.id]
+              const isSaving = isPending && pendingPropertyId === property.id
+              return (
+                <form
+                  key={property.id}
+                  className="grid gap-4 px-4 py-5 sm:grid-cols-[minmax(0,320px)_1fr]"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    const form = event.currentTarget
+                    const data = new FormData(form)
+                    handleSubmit(property.id, data)
+                  }}
+                >
+                  <div className="space-y-3">
+                    <div>
+                      <h4 className="text-sm font-semibold text-gray-900">{property.propertyLabel}</h4>
+                      <p className="text-xs text-gray-500">
+                        {property.companyName || property.clientName || 'Client account'}
+                      </p>
+                    </div>
+                    <div className="rounded-lg border border-gray-200 bg-white/60 p-3 text-xs text-gray-600">
+                      <p className="font-medium text-gray-800">Schedule</p>
+                      <dl className="mt-1 space-y-1">
+                        <div className="flex justify-between gap-2">
+                          <dt>Put bins out:</dt>
+                          <dd className="text-right font-medium text-gray-900">
+                            {property.putBinsOut?.length ? property.putBinsOut : '—'}
+                          </dd>
+                        </div>
+                        <div className="flex justify-between gap-2">
+                          <dt>Collection day:</dt>
+                          <dd className="text-right font-medium text-gray-900">
+                            {property.collectionDay?.length ? property.collectionDay : '—'}
+                          </dd>
+                        </div>
+                        <div className="flex justify-between gap-2">
+                          <dt>Bins:</dt>
+                          <dd className="text-right font-medium text-gray-900">
+                            {property.binSummary?.length ? property.binSummary : '—'}
+                          </dd>
+                        </div>
+                      </dl>
+                    </div>
+                  </div>
+
+                  <div className="space-y-4">
+                    <div className="grid gap-2">
+                      <label htmlFor={`address-${property.id}`} className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        Service address
+                      </label>
+                      <textarea
+                        id={`address-${property.id}`}
+                        name="address"
+                        defaultValue={property.address}
+                        rows={2}
+                        className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-[#ff5757] focus:outline-none focus:ring-2 focus:ring-[#ff5757]/40"
+                      />
+                    </div>
+
+                    <div className="grid gap-2 sm:grid-cols-2 sm:gap-4">
+                      <div className="grid gap-2">
+                        <label htmlFor={`collectionDay-${property.id}`} className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Collection day
+                        </label>
+                        <input
+                          id={`collectionDay-${property.id}`}
+                          name="collectionDay"
+                          defaultValue={property.collectionDay ?? ''}
+                          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-[#ff5757] focus:outline-none focus:ring-2 focus:ring-[#ff5757]/40"
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <label htmlFor={`putBinsOut-${property.id}`} className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Put bins out
+                        </label>
+                        <input
+                          id={`putBinsOut-${property.id}`}
+                          name="putBinsOut"
+                          defaultValue={property.putBinsOut ?? ''}
+                          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-[#ff5757] focus:outline-none focus:ring-2 focus:ring-[#ff5757]/40"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <label htmlFor={`notes-${property.id}`} className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        Internal notes
+                      </label>
+                      <textarea
+                        id={`notes-${property.id}`}
+                        name="notes"
+                        defaultValue={property.notes ?? ''}
+                        rows={3}
+                        className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-[#ff5757] focus:outline-none focus:ring-2 focus:ring-[#ff5757]/40"
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <label htmlFor={`assignedTo-${property.id}`} className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                        Assigned staff
+                      </label>
+                      <select
+                        id={`assignedTo-${property.id}`}
+                        name="assignedTo"
+                        defaultValue={property.assignedTo ?? ''}
+                        className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-[#ff5757] focus:outline-none focus:ring-2 focus:ring-[#ff5757]/40"
+                      >
+                        {staffOptions.map((option) => (
+                          <option key={`${property.id}-${option.value || 'unassigned'}`} value={option.value}>
+                            {option.label}
+                            {option.role !== 'none' ? option.role === 'admin' ? ' (Admin)' : ' (Staff)' : ''}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="flex items-center justify-between gap-3">
+                      <button
+                        type="submit"
+                        className="inline-flex items-center justify-center rounded-lg bg-[#ff5757] px-4 py-2 text-sm font-semibold text-black shadow-sm transition focus:outline-none focus:ring-2 focus:ring-[#ff5757]/40 disabled:cursor-not-allowed disabled:opacity-70"
+                        disabled={isSaving}
+                      >
+                        {isSaving ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Saving…
+                          </>
+                        ) : (
+                          'Save changes'
+                        )}
+                      </button>
+                      {status && (
+                        <div
+                          className={`inline-flex items-center gap-1 text-sm ${
+                            status.variant === 'success' ? 'text-green-600' : 'text-red-600'
+                          }`}
+                        >
+                          {status.variant === 'success' ? (
+                            <CheckCircle2 className="h-4 w-4" />
+                          ) : (
+                            <AlertCircle className="h-4 w-4" />
+                          )}
+                          <span>{status.message}</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </form>
+              )
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add an admin-only management route that groups client_list records by account and loads staff rosters via Supabase
- build an AdminManagementTable UI to edit property details and assignments with inline success and error messaging
- wire up a server action to persist client updates, revalidate the page, and surface the screen from the admin dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9fc91cd388332ba40efd652aa58d1