### PR TITLE
Add metadata to Supabase sign up flow

### DIFF
--- a/app/auth/sign-up/SignUpClient.tsx
+++ b/app/auth/sign-up/SignUpClient.tsx
@@ -49,6 +49,10 @@ export default function SignUpClient() {
       password,
       options: {
         emailRedirectTo: `${window.location.origin}/auth/callback`,
+        data: {
+          full_name: name,
+          phone: `${countryCode}${phone}`,
+        },
       },
     });
 


### PR DESCRIPTION
## Summary
- include full name and phone number in the Supabase sign up payload so they are stored in auth metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dccfb4fa3c833293964a174a43dcfe