### PR TITLE
Fix client portal data loading and upgrade tracker map

### DIFF
--- a/components/client/LiveTracker.tsx
+++ b/components/client/LiveTracker.tsx
@@ -47,8 +47,19 @@ function Stepper({ status }: { status: typeof STEPS[number]['key'] }) {
 export function LiveTracker() {
   const { jobs, properties, selectedAccount, upsertJob, refreshJobs, jobsLoading } = useClientPortal()
   const activeJobs = useMemo(() => jobs.filter((job) => job.status !== 'completed' && job.status !== 'skipped'), [jobs])
+  const realtimePropertyIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          properties
+            .map((property) => property.id)
+            .filter((value): value is string => Boolean(value)),
+        ),
+      ),
+    [properties],
+  )
 
-  useRealtimeJobs(selectedAccount?.id ?? null, (job) => {
+  useRealtimeJobs(selectedAccount?.id ?? null, realtimePropertyIds, (job) => {
     upsertJob(job)
   })
 

--- a/hooks/useRealtimeJobs.ts
+++ b/hooks/useRealtimeJobs.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import type { RealtimeChannel } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabaseClient'
 import type { Job } from '@/components/client/ClientPortalProvider'
 import { nextDay, setHours, setMinutes, startOfToday } from 'date-fns'
@@ -27,48 +28,97 @@ const computeNextOccurrence = (dayOfWeek: string | null): string => {
   return withHour.toISOString()
 }
 
-export function useRealtimeJobs(accountId: string | null, onChange: (job: Job) => void) {
-  useEffect(() => {
-    if (!accountId) return
+const normaliseId = (value: string | null | undefined): string | null => {
+  if (!value) return null
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
 
-    const channel = supabase
-      .channel(`jobs-client-${accountId}`)
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'jobs', filter: `account_id=eq.${accountId}` },
-        (payload) => {
-          const newJob = payload.new as any
-          if (!newJob) return
-          const scheduledAt = computeNextOccurrence(newJob.day_of_week ?? null)
-          const bins = typeof newJob.bins === 'string' ? newJob.bins.split(',').map((value: string) => value.trim()) : []
-          const propertyId =
-            typeof newJob.property_id === 'string' && newJob.property_id.trim().length ? newJob.property_id.trim() : null
-          const job: Job = {
-            id: String(newJob.id),
-            accountId,
-            propertyId,
-            propertyName: newJob.address ?? 'Property',
-            status: 'scheduled',
-            scheduledAt,
-            etaMinutes: null,
-            startedAt: null,
-            completedAt: newJob.last_completed_on ?? null,
-            crewName: null,
-            proofPhotoKeys: newJob.photo_path ? [newJob.photo_path] : [],
-            routePolyline: null,
-            lastLatitude: newJob.lat ?? undefined,
-            lastLongitude: newJob.lng ?? undefined,
-            notes: newJob.notes ?? null,
-            jobType: newJob.job_type ?? null,
-            bins,
-          }
-          onChange(job)
-        },
-      )
-      .subscribe()
+const createJobFromPayload = (payload: any, fallbackAccountId: string | null): Job | null => {
+  if (!payload) return null
+  const scheduledAt = computeNextOccurrence(payload.day_of_week ?? null)
+  const bins =
+    typeof payload.bins === 'string'
+      ? payload.bins.split(',').map((value: string) => value.trim())
+      : []
+  const propertyId = normaliseId(payload.property_id)
+  const accountId = normaliseId(payload.account_id) ?? fallbackAccountId ?? 'unknown'
+  return {
+    id: String(payload.id),
+    accountId,
+    propertyId,
+    propertyName: payload.address ?? 'Property',
+    status: 'scheduled',
+    scheduledAt,
+    etaMinutes: null,
+    startedAt: null,
+    completedAt: payload.last_completed_on ?? null,
+    crewName: null,
+    proofPhotoKeys: payload.photo_path ? [payload.photo_path] : [],
+    routePolyline: null,
+    lastLatitude: payload.lat ?? undefined,
+    lastLongitude: payload.lng ?? undefined,
+    notes: payload.notes ?? null,
+    jobType: payload.job_type ?? null,
+    bins,
+  }
+}
+
+export function useRealtimeJobs(
+  accountId: string | null,
+  propertyIds: string[],
+  onChange: (job: Job) => void,
+) {
+  useEffect(() => {
+    const uniquePropertyIds = Array.from(
+      new Set(
+        propertyIds
+          .map((value) => normaliseId(value))
+          .filter((value): value is string => Boolean(value)),
+      ),
+    )
+
+    if (!accountId && uniquePropertyIds.length === 0) {
+      return
+    }
+
+    const channels: RealtimeChannel[] = []
+
+    const handleChange = (payload: { new: any }) => {
+      const job = createJobFromPayload(payload.new, accountId)
+      if (job) {
+        onChange(job)
+      }
+    }
+
+    if (accountId) {
+      const channel = supabase
+        .channel(`jobs-client-account-${accountId}`)
+        .on(
+          'postgres_changes',
+          { event: '*', schema: 'public', table: 'jobs', filter: `account_id=eq.${accountId}` },
+          handleChange,
+        )
+        .subscribe()
+      channels.push(channel)
+    }
+
+    uniquePropertyIds.forEach((propertyId) => {
+      const channel = supabase
+        .channel(`jobs-client-property-${propertyId}`)
+        .on(
+          'postgres_changes',
+          { event: '*', schema: 'public', table: 'jobs', filter: `property_id=eq.${propertyId}` },
+          handleChange,
+        )
+        .subscribe()
+      channels.push(channel)
+    })
 
     return () => {
-      supabase.removeChannel(channel)
+      channels.forEach((channel) => {
+        supabase.removeChannel(channel)
+      })
     }
-  }, [accountId, onChange])
+  }, [accountId, onChange, propertyIds])
 }


### PR DESCRIPTION
## Summary
- expand client portal job fetching to include account and property scoped records and merge matching logs safely
- feed realtime updates with per-property subscriptions and hook the portal to pass property identifiers
- replace the static tracker heatmap with a styled Google Map using saved preferences, live markers, and empty-state messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd895b415c83328bc120f725909c3b