### PR TITLE
Handle numeric client metadata identifiers for portal access

### DIFF
--- a/components/client/ClientPortalProvider.tsx
+++ b/components/client/ClientPortalProvider.tsx
@@ -191,19 +191,19 @@ const extractIdentifierArray = (
 ): string[] => {
   if (!metadata) return []
   const identifiers = new Set<string>()
+  const register = (value: string | number | null | undefined) => {
+    const normalised = normaliseIdentifier(value)
+    if (normalised) {
+      identifiers.add(normalised)
+    }
+  }
   const addValue = (raw: unknown) => {
-    if (typeof raw === 'string') {
-      const normalised = normaliseIdentifier(raw)
-      if (normalised) {
-        identifiers.add(normalised)
-      }
+    if (typeof raw === 'string' || typeof raw === 'number') {
+      register(raw)
     } else if (Array.isArray(raw)) {
       raw.forEach((entry) => {
-        if (typeof entry === 'string') {
-          const normalised = normaliseIdentifier(entry)
-          if (normalised) {
-            identifiers.add(normalised)
-          }
+        if (typeof entry === 'string' || typeof entry === 'number') {
+          register(entry)
         }
       })
     }


### PR DESCRIPTION
## Summary
- include numeric metadata values when extracting client account and property identifiers
- ensure client portal can load linked properties for users with numeric identifiers

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9b8bd91083328ddd67c54b67f4ff