### PR TITLE
Align client portal token flows with Supabase RLS

### DIFF
--- a/app/ops/tokens/page.tsx
+++ b/app/ops/tokens/page.tsx
@@ -1,64 +1,131 @@
 // app/ops/tokens/page.tsx
 import BackButton from '@/components/UI/BackButton'
+import {
+  deriveAccountId,
+  deriveAccountName,
+  type PortalClientRow,
+} from '@/lib/clientPortalAccess'
 import { supabaseServer } from '@/lib/supabaseServer'
-
-type ClientListRow = {
-  id: string
-  account_id: string | null
-  client_name: string | null
-  company: string | null
-}
-
-const deriveAccountId = (row: ClientListRow): string =>
-  (row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.id)
-
-const deriveAccountName = (row: ClientListRow): string =>
-  row.company?.trim() || row.client_name?.trim() || 'Client Account'
 
 export default async function TokensPage() {
   const sb = supabaseServer()
 
-  const { data: clientRows, error: clientError } = await sb
-    .from('client_list')
-    .select('id, account_id, client_name, company')
+  const { data: tokenRows, error: tokenError } = await sb
+    .from('client_portal_tokens')
+    .select('token, account_id, property_id, created_at, expires_at')
 
-  if (clientError) {
+  if (tokenError) {
     return (
       <div className="container">
         <BackButton />
         <h2>Error loading client accounts</h2>
-        <p className="text-red-500">{clientError.message}</p>
+        <p className="text-red-500">{tokenError.message}</p>
       </div>
     )
   }
 
-  const accountsMap = new Map<
+  const tokens = tokenRows ?? []
+
+  const accountIds = new Set<string>()
+  const propertyIds = new Set<string>()
+
+  tokens.forEach((row) => {
+    const accountId = row.account_id?.trim()
+    if (accountId) {
+      accountIds.add(accountId)
+    }
+    const propertyId = row.property_id?.trim()
+    if (propertyId) {
+      propertyIds.add(propertyId)
+    }
+  })
+
+  let clientRows: PortalClientRow[] = []
+
+  if (accountIds.size || propertyIds.size) {
+    const filters: string[] = []
+    const escape = (value: string) => value.replace(/,/g, '\\,').replace(/'/g, "''")
+
+    accountIds.forEach((accountId) => {
+      filters.push(`account_id.eq.${escape(accountId)}`)
+    })
+
+    propertyIds.forEach((propertyId) => {
+      filters.push(`id.eq.${escape(propertyId)}`)
+    })
+
+    const { data, error } = await sb
+      .from('client_list')
+      .select('id, account_id, client_name, company, address, notes')
+      .or(filters.join(','))
+
+    if (error) {
+      return (
+        <div className="container">
+          <BackButton />
+          <h2>Error loading client accounts</h2>
+          <p className="text-red-500">{error.message}</p>
+        </div>
+      )
+    }
+
+    clientRows = (data ?? []).map((row) => ({
+      id: row.id,
+      account_id: row.account_id,
+      client_name: row.client_name,
+      company: row.company,
+      address: row.address,
+      notes: row.notes,
+    }))
+  }
+
+  const clientsById = new Map<string, PortalClientRow>()
+  clientRows.forEach((row) => {
+    clientsById.set(row.id, row)
+  })
+
+  const accountsById = new Map<
     string,
     {
       id: string
       name: string
-      propertyCount: number
+      properties: PortalClientRow[]
     }
   >()
 
-  ;((clientRows ?? []) as ClientListRow[]).forEach((row) => {
+  clientRows.forEach((row) => {
     const accountId = deriveAccountId(row)
-    const accountName = deriveAccountName(row)
-    const existing = accountsMap.get(accountId)
+    const existing = accountsById.get(accountId)
     if (existing) {
-      existing.propertyCount += 1
+      existing.properties.push(row)
     } else {
-      accountsMap.set(accountId, {
+      accountsById.set(accountId, {
         id: accountId,
-        name: accountName,
-        propertyCount: 1,
+        name: deriveAccountName(row),
+        properties: [row],
       })
     }
   })
 
-  const accounts = Array.from(accountsMap.values()).sort((a, b) =>
-    a.name.localeCompare(b.name),
-  )
+  const decoratedTokens = tokens.map((row) => {
+    const property = row.property_id ? clientsById.get(row.property_id) ?? null : null
+    const explicitAccountId = row.account_id?.trim() ?? null
+    const resolvedAccountId = explicitAccountId ?? (property ? deriveAccountId(property) : null)
+    const account = resolvedAccountId ? accountsById.get(resolvedAccountId) : null
+
+    return {
+      token: row.token,
+      href: `/c/${encodeURIComponent(row.token)}`,
+      accountName: property ? deriveAccountName(property) : account?.name ?? resolvedAccountId ?? 'Client Account',
+      scopeDescription: property
+        ? property.address ?? property.client_name ?? 'Property'
+        : `${account?.properties.length ?? 0} properties`,
+      createdAt: row.created_at,
+      expiresAt: row.expires_at,
+    }
+  })
+
+  decoratedTokens.sort((a, b) => a.accountName.localeCompare(b.accountName))
 
   return (
     <div className="container">
@@ -72,23 +139,25 @@ export default async function TokensPage() {
       </p>
 
       <h3 className="font-medium mb-2">Available links</h3>
-      {accounts.length === 0 ? (
+      {decoratedTokens.length === 0 ? (
         <p className="text-sm text-gray-600">No client records found.</p>
       ) : (
         <ul className="list-disc list-inside space-y-1">
-          {accounts.map((account) => {
-            const href = `/c/${encodeURIComponent(account.id)}`
-            return (
-              <li key={account.id}>
-                <a target="_blank" href={href} rel="noreferrer">
-                  {account.name} — {href}
-                </a>
-                <span className="ml-2 text-xs text-gray-500">
-                  ({account.propertyCount} properties)
+          {decoratedTokens.map((entry) => (
+            <li key={entry.token}>
+              <a target="_blank" href={entry.href} rel="noreferrer">
+                {entry.accountName} — {entry.href}
+              </a>
+              <span className="ml-2 text-xs text-gray-500">
+                ({entry.scopeDescription})
+              </span>
+              {entry.expiresAt && (
+                <span className="ml-2 text-xs text-gray-400">
+                  Expires {new Date(entry.expiresAt).toLocaleDateString()}
                 </span>
-              </li>
-            )
-          })}
+              )}
+            </li>
+          ))}
         </ul>
       )}
     </div>

--- a/lib/clientPortalAccess.ts
+++ b/lib/clientPortalAccess.ts
@@ -1,0 +1,182 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type PortalClientRow = {
+  id: string
+  account_id: string | null
+  client_name: string | null
+  company: string | null
+  address: string | null
+  notes: string | null
+}
+
+type PortalTokenRow = {
+  account_id: string | null
+  property_id: string | null
+  expires_at: string | null
+}
+
+const escapeFilterValue = (value: string) => value.replace(/,/g, '\\,').replace(/'/g, "''")
+
+export const deriveAccountId = (row: PortalClientRow): string => {
+  const explicit = row.account_id?.trim()
+  return explicit && explicit.length > 0 ? explicit : row.id
+}
+
+export const deriveAccountName = (row: PortalClientRow): string =>
+  row.company?.trim() || row.client_name?.trim() || 'Client Account'
+
+async function fetchPortalClientRows(
+  supabase: SupabaseClient,
+  accountIds: string[],
+  propertyIds: string[],
+): Promise<PortalClientRow[]> {
+  const filters: string[] = []
+
+  accountIds.forEach((accountId) => {
+    const trimmed = accountId.trim()
+    if (trimmed) {
+      filters.push(`account_id.eq.${escapeFilterValue(trimmed)}`)
+    }
+  })
+
+  propertyIds.forEach((propertyId) => {
+    const trimmed = propertyId.trim()
+    if (trimmed) {
+      filters.push(`id.eq.${escapeFilterValue(trimmed)}`)
+    }
+  })
+
+  if (!filters.length) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from('client_list')
+    .select('id, account_id, client_name, company, address, notes')
+    .or(filters.join(','))
+
+  if (error) {
+    console.warn('Failed to load client portal rows', error)
+    return []
+  }
+
+  const deduped = new Map<string, PortalClientRow>()
+
+  ;(data ?? []).forEach((row) => {
+    const id = typeof row.id === 'string' ? row.id.trim() : null
+    if (!id) return
+
+    deduped.set(id, {
+      id,
+      account_id: typeof row.account_id === 'string' ? row.account_id : null,
+      client_name: typeof row.client_name === 'string' ? row.client_name : null,
+      company: typeof row.company === 'string' ? row.company : null,
+      address: typeof row.address === 'string' ? row.address : null,
+      notes: typeof row.notes === 'string' ? row.notes : null,
+    })
+  })
+
+  return Array.from(deduped.values())
+}
+
+const tokenExpired = (row: PortalTokenRow | null): boolean => {
+  if (!row?.expires_at) return false
+  const expiresAt = Date.parse(row.expires_at)
+  if (Number.isNaN(expiresAt)) return false
+  return expiresAt < Date.now()
+}
+
+export type PortalScope = {
+  accountId: string
+  accountName: string
+  propertyIds: string[]
+  rows: PortalClientRow[]
+  expiresAt: string | null
+}
+
+export async function resolvePortalScope(
+  supabase: SupabaseClient,
+  token: string,
+): Promise<PortalScope | null> {
+  const trimmedToken = token.trim()
+  if (!trimmedToken) {
+    return null
+  }
+
+  const { data: tokenRow, error: tokenError } = await supabase
+    .from('client_portal_tokens')
+    .select('account_id, property_id, expires_at')
+    .eq('token', trimmedToken)
+    .maybeSingle()
+
+  if (tokenError) {
+    console.warn('Failed to validate client portal token', tokenError)
+    return null
+  }
+
+  if (!tokenRow || tokenExpired(tokenRow)) {
+    return null
+  }
+
+  const candidateAccountIds: string[] = []
+  const candidatePropertyIds: string[] = []
+
+  if (tokenRow.account_id && tokenRow.account_id.trim().length) {
+    candidateAccountIds.push(tokenRow.account_id.trim())
+  }
+
+  if (tokenRow.property_id && tokenRow.property_id.trim().length) {
+    candidatePropertyIds.push(tokenRow.property_id.trim())
+  }
+
+  const clientRows = await fetchPortalClientRows(
+    supabase,
+    candidateAccountIds,
+    candidatePropertyIds,
+  )
+
+  if (!clientRows.length) {
+    return null
+  }
+
+  const canonicalAccountId =
+    candidateAccountIds.find((value) => value.trim().length) ??
+    (() => {
+      if (tokenRow.property_id) {
+        const target = clientRows.find((row) => row.id === tokenRow.property_id)
+        return target ? deriveAccountId(target) : null
+      }
+      return deriveAccountId(clientRows[0]!)
+    })()
+
+  if (!canonicalAccountId) {
+    return null
+  }
+
+  const scopedRows = tokenRow.property_id
+    ? clientRows.filter((row) => row.id === tokenRow.property_id)
+    : clientRows.filter((row) => deriveAccountId(row) === canonicalAccountId)
+
+  if (!scopedRows.length) {
+    return null
+  }
+
+  return {
+    accountId: canonicalAccountId,
+    accountName: deriveAccountName(scopedRows[0]!),
+    propertyIds: scopedRows.map((row) => row.id),
+    rows: scopedRows,
+    expiresAt: tokenRow.expires_at,
+  }
+}
+
+export const buildOrFilters = (field: string, values: string[]): string[] => {
+  const filters: string[] = []
+  values.forEach((value) => {
+    const trimmed = value.trim()
+    if (trimmed.length) {
+      filters.push(`${field}.eq.${escapeFilterValue(trimmed)}`)
+    }
+  })
+  return filters
+}


### PR DESCRIPTION
## Summary
- add shared client portal helpers that resolve permitted accounts/properties from `client_portal_tokens`
- update the public client portal page to scope jobs and logs queries to the resolved account/property set
- validate portal links in middleware and refresh the ops token listing from the dedicated tokens table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9e1a0694833298bb570e892ad686