### PR TITLE
Update portal data lookups to new property_id schema

### DIFF
--- a/app/c/[token]/page.tsx
+++ b/app/c/[token]/page.tsx
@@ -5,7 +5,7 @@ import { supabaseServer } from '@/lib/supabaseServer'
 import type { JobRecord, Property } from '@/lib/database.types'
 
 const toProperty = (row: PortalClientRow): Property => ({
-  id: row.id,
+  property_id: row.property_id,
   address: row.address,
   notes: row.notes,
 })
@@ -94,7 +94,7 @@ export default async function ClientPortal({
       {properties.length ? (
         <ul className="space-y-2">
           {properties.map((p) => (
-            <li key={p.id} className="p-3 border rounded">
+            <li key={p.property_id} className="p-3 border rounded">
               <p className="font-medium">{p.address}</p>
               <p className="text-sm opacity-70">{p.notes || 'No notes'}</p>
             </li>

--- a/app/ops/clients/page.tsx
+++ b/app/ops/clients/page.tsx
@@ -3,7 +3,7 @@ import BackButton from '@/components/UI/BackButton'
 import { supabaseServer } from '@/lib/supabaseServer'
 
 type ClientListRow = {
-  id: string
+  property_id: string
   client_name: string | null
   company: string | null
   address: string | null
@@ -63,7 +63,7 @@ async function fetchClientRows(): Promise<TableRow[]> {
   const { data, error } = await sb
     .from('client_list')
     .select(
-      'id, client_name, company, address, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip',
+      'property_id, client_name, company, address, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip',
     )
 
   if (error) {
@@ -72,7 +72,7 @@ async function fetchClientRows(): Promise<TableRow[]> {
   }
 
   return ((data ?? []) as ClientListRow[]).map((row) => ({
-    id: row.id,
+    id: row.property_id,
     name: deriveName(row),
     address: deriveAddress(row),
     binsThisWeek: deriveBinsThisWeek(row),

--- a/app/ops/generate/page.tsx
+++ b/app/ops/generate/page.tsx
@@ -27,7 +27,7 @@ const DAY_ALIASES: Record<string, number> = {
 }
 
 type ClientListRow = {
-  id: string
+  property_id: string
   account_id: string | null
   client_name: string | null
   company: string | null
@@ -101,7 +101,7 @@ const describeBinFrequency = (color: string, frequency: string | null, flip: str
 }
 
 const deriveAccountId = (row: ClientListRow): string =>
-  (row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.id)
+  row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.property_id
 
 const deriveClientName = (row: ClientListRow): string =>
   row.client_name?.trim() || row.company?.trim() || 'Client'
@@ -131,7 +131,7 @@ async function generateJobs() {
   const { data: clients, error: clientError } = await sb
     .from('client_list')
     .select(
-      `id, account_id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, lat_lng, photo_path, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip`,
+      `property_id, account_id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, lat_lng, photo_path, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip`,
     )
 
   if (clientError) {
@@ -156,7 +156,7 @@ async function generateJobs() {
     if (matchesDay(client.put_bins_out, dayIndex)) {
       jobs.push({
         account_id: accountId,
-        property_id: client.id,
+        property_id: client.property_id,
         address,
         lat,
         lng,
@@ -174,7 +174,7 @@ async function generateJobs() {
     if (matchesDay(client.collection_day, dayIndex)) {
       jobs.push({
         account_id: accountId,
-        property_id: client.id,
+        property_id: client.property_id,
         address,
         lat,
         lng,

--- a/app/ops/tokens/page.tsx
+++ b/app/ops/tokens/page.tsx
@@ -51,12 +51,12 @@ export default async function TokensPage() {
     })
 
     propertyIds.forEach((propertyId) => {
-      filters.push(`id.eq.${escape(propertyId)}`)
+      filters.push(`property_id.eq.${escape(propertyId)}`)
     })
 
     const { data, error } = await sb
       .from('client_list')
-      .select('id, account_id, client_name, company, address, notes')
+      .select('property_id, account_id, client_name, company, address, notes')
       .or(filters.join(','))
 
     if (error) {
@@ -70,7 +70,7 @@ export default async function TokensPage() {
     }
 
     clientRows = (data ?? []).map((row) => ({
-      id: row.id,
+      property_id: row.property_id,
       account_id: row.account_id,
       client_name: row.client_name,
       company: row.company,
@@ -81,7 +81,7 @@ export default async function TokensPage() {
 
   const clientsById = new Map<string, PortalClientRow>()
   clientRows.forEach((row) => {
-    clientsById.set(row.id, row)
+    clientsById.set(row.property_id, row)
   })
 
   const accountsById = new Map<

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1,7 +1,7 @@
 // lib/database.types.ts
 
 export type Property = {
-  id: string
+  property_id: string
   address: string | null
   notes: string | null
 }


### PR DESCRIPTION
## Summary
- update client portal scope resolution and server pages to query `client_list.property_id`
- adjust client portal provider logic and job generation to derive account scopes using property identifiers
- align shared property typing and portal rendering with the updated property identifier

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df358cc0e08332bae1bf6c66d5aca5