### PR TITLE
Use property address labels and update bin names

### DIFF
--- a/__tests__/JobHistoryTable.test.tsx
+++ b/__tests__/JobHistoryTable.test.tsx
@@ -26,7 +26,7 @@ const jobs: Job[] = [
     lastLongitude: null,
     notes: null,
     jobType: 'bring_in',
-    bins: ['Red', 'Yellow'],
+    bins: ['Landfill', 'Recycling'],
   },
 ]
 

--- a/__tests__/computeEtaLabel.test.ts
+++ b/__tests__/computeEtaLabel.test.ts
@@ -18,7 +18,7 @@ const baseJob: Job = {
   lastLongitude: null,
   notes: null,
   jobType: 'bring_in',
-  bins: ['Red'],
+  bins: ['Landfill'],
 }
 
 describe('computeEtaLabel', () => {

--- a/app/ops/clients/page.tsx
+++ b/app/ops/clients/page.tsx
@@ -24,12 +24,12 @@ type TableRow = {
 }
 
 const describeBinFrequency = (
-  color: string,
+  label: string,
   frequency: string | null,
   flip: string | null,
 ): string | null => {
   if (!frequency) return null
-  const base = `${color} (${frequency.toLowerCase()})`
+  const base = `${label} (${frequency.toLowerCase()})`
   if (frequency === 'Fortnightly' && flip === 'Yes') {
     return `${base}, alternate weeks`
   }
@@ -40,9 +40,9 @@ const describeBinFrequency = (
 const deriveBinsThisWeek = (row: ClientListRow): string => {
   const bins = [
 
-    describeBinFrequency('Red', row.red_freq, row.red_flip),
-    describeBinFrequency('Yellow', row.yellow_freq, row.yellow_flip),
-    describeBinFrequency('Green', row.green_freq, row.green_flip),
+    describeBinFrequency('Landfill', row.red_freq, row.red_flip),
+    describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip),
+    describeBinFrequency('Organic', row.green_freq, row.green_flip),
   ].filter(Boolean) as string[]
 
 

--- a/app/ops/generate/page.tsx
+++ b/app/ops/generate/page.tsx
@@ -91,9 +91,13 @@ const parseLatLng = (value: string | null): { lat: number | null; lng: number | 
   }
 }
 
-const describeBinFrequency = (color: string, frequency: string | null, flip: string | null) => {
+const describeBinFrequency = (
+  label: string,
+  frequency: string | null,
+  flip: string | null,
+) => {
   if (!frequency) return null
-  const base = `${color} (${frequency.toLowerCase()})`
+  const base = `${label} (${frequency.toLowerCase()})`
   if (frequency === 'Fortnightly' && flip === 'Yes') {
     return `${base}, alternate weeks`
   }
@@ -108,9 +112,9 @@ const deriveClientName = (row: ClientListRow): string =>
 
 const buildBinsSummary = (row: ClientListRow): string | null => {
   const bins = [
-    describeBinFrequency('Red', row.red_freq, row.red_flip),
-    describeBinFrequency('Yellow', row.yellow_freq, row.yellow_flip),
-    describeBinFrequency('Green', row.green_freq, row.green_flip),
+    describeBinFrequency('Landfill', row.red_freq, row.red_flip),
+    describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip),
+    describeBinFrequency('Organic', row.green_freq, row.green_flip),
   ].filter(Boolean) as string[]
 
   if (!bins.length) return null

--- a/components/client/ClientPortalProvider.tsx
+++ b/components/client/ClientPortalProvider.tsx
@@ -251,9 +251,13 @@ const extractEmailCandidates = (user: User): string[] => {
   return Array.from(emails)
 }
 
-const describeBinFrequency = (color: string, frequency: string | null, flip: string | null) => {
+const describeBinFrequency = (
+  label: string,
+  frequency: string | null,
+  flip: string | null,
+) => {
   if (!frequency) return null
-  const base = `${color} (${frequency.toLowerCase()})`
+  const base = `${label} (${frequency.toLowerCase()})`
   if (frequency === 'Fortnightly' && flip === 'Yes') {
     return `${base}, alternate weeks`
   }
@@ -285,9 +289,9 @@ const toProperty = (row: ClientListRow): Property => {
   const [addressLine, suburbRaw = ''] = (row.address ?? '').split(',')
   const suburb = suburbRaw.trim()
   const binTypes = [
-    describeBinFrequency('Red', row.red_freq, row.red_flip),
-    describeBinFrequency('Yellow', row.yellow_freq, row.yellow_flip),
-    describeBinFrequency('Green', row.green_freq, row.green_flip),
+    describeBinFrequency('Landfill', row.red_freq, row.red_flip),
+    describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip),
+    describeBinFrequency('Organic', row.green_freq, row.green_flip),
   ].filter(Boolean) as string[]
   const nextServiceAt = row.collection_day ? nextOccurrenceIso(row.collection_day) : null
   const { lat, lng } = parseLatLng(row.lat_lng)
@@ -296,7 +300,7 @@ const toProperty = (row: ClientListRow): Property => {
     : Boolean(row.trial_start)
   return {
     id: row.property_id,
-    name: row.client_name ?? addressLine ?? 'Property',
+    name: addressLine || row.client_name || 'Property',
     addressLine: (addressLine ?? '').trim(),
     suburb,
     city: suburb,

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { format } from 'date-fns'
-import { MapPinIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import type { Property } from './ClientPortalProvider'
 import { PropertyFilters, type PropertyFilterState } from './PropertyFilters'
 
@@ -96,11 +96,9 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                   >
                     <div className="flex items-start justify-between gap-4">
                       <div>
-                        <h4 className="text-xl font-semibold text-white">{property.name}</h4>
-                        <p className="mt-1 flex items-center gap-2 text-sm text-white/60">
-                          <MapPinIcon className="h-4 w-4" />
+                        <h4 className="text-xl font-semibold text-white">
                           {property.addressLine}, {property.suburb}
-                        </p>
+                        </h4>
                       </div>
                       <span
                         className="rounded-full border border-white/20 px-3 py-1 text-xs uppercase tracking-wide text-white/70"


### PR DESCRIPTION
## Summary
- derive property names from their street addresses instead of client names in the client portal
- rename bin frequency labels to Landfill, Recycling, and Organic across client and ops views
- update related unit tests to reflect the new bin naming convention

## Testing
- npm test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df4da856a0833290a3378359a01ccd