### PR TITLE
Normalize client bin labels and refine live tracker results

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -5,6 +5,7 @@ import { format } from 'date-fns'
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import type { Property } from './ClientPortalProvider'
 import { PropertyFilters, type PropertyFilterState } from './PropertyFilters'
+import { formatBinLabel } from '@/lib/binLabels'
 
 const DEFAULT_FILTERS: PropertyFilterState = {
   search: '',
@@ -23,10 +24,11 @@ function matchesFilters(property: Property, filters: PropertyFilterState) {
   }
   if (filters.binType !== 'all') {
     const hasBinType = property.binTypes.some((bin) => {
-      const normalised = bin.toLowerCase()
-      if (filters.binType === 'landfill') return normalised.includes('red') || normalised.includes('landfill')
-      if (filters.binType === 'recycling') return normalised.includes('yellow') || normalised.includes('recycle')
-      return normalised.includes('green') || normalised.includes('organic')
+      const label = formatBinLabel(bin)
+      if (!label) return false
+      if (filters.binType === 'landfill') return label === 'Landfill'
+      if (filters.binType === 'recycling') return label === 'Recycling'
+      return label === 'Compost'
     })
     if (!hasBinType) return false
   }

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -4,11 +4,12 @@ import { useMemo } from 'react'
 import clsx from 'clsx'
 import { FunnelIcon } from '@heroicons/react/24/outline'
 import type { Property } from './ClientPortalProvider'
+import { formatBinLabel } from '@/lib/binLabels'
 
 export type PropertyFilterState = {
   search: string
   status: 'all' | 'active' | 'paused'
-  binType: 'all' | 'landfill' | 'recycling' | 'organics'
+  binType: 'all' | 'landfill' | 'recycling' | 'compost'
   groupBy: 'city' | 'status'
 }
 
@@ -16,7 +17,7 @@ const BIN_LABELS: Record<PropertyFilterState['binType'], string> = {
   all: 'All bins',
   landfill: 'Landfill',
   recycling: 'Recycling',
-  organics: 'Organics',
+  compost: 'Compost',
 }
 
 const STATUS_LABELS: Record<PropertyFilterState['status'], string> = {
@@ -36,13 +37,14 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
     const totalBins = properties.reduce(
       (accumulator, property) => {
         property.binTypes.forEach((bin) => {
-          if (bin.toLowerCase().includes('recycle')) accumulator.recycling += 1
-          else if (bin.toLowerCase().includes('green') || bin.toLowerCase().includes('organic')) accumulator.organics += 1
-          else accumulator.landfill += 1
+          const label = formatBinLabel(bin)
+          if (label === 'Recycling') accumulator.recycling += 1
+          else if (label === 'Compost') accumulator.compost += 1
+          else if (label === 'Landfill') accumulator.landfill += 1
         })
         return accumulator
       },
-      { landfill: 0, recycling: 0, organics: 0 },
+      { landfill: 0, recycling: 0, compost: 0 },
     )
 
     return totalBins
@@ -125,8 +127,8 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
           <dd className="mt-1 text-2xl font-semibold">{totals.recycling}</dd>
         </div>
         <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-          <dt className="text-xs uppercase tracking-wide text-white/50">Organics bins</dt>
-          <dd className="mt-1 text-2xl font-semibold">{totals.organics}</dd>
+          <dt className="text-xs uppercase tracking-wide text-white/50">Compost bins</dt>
+          <dd className="mt-1 text-2xl font-semibold">{totals.compost}</dd>
         </div>
       </dl>
     </section>

--- a/hooks/useRealtimeJobs.ts
+++ b/hooks/useRealtimeJobs.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import type { RealtimeChannel } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabaseClient'
 import type { Job } from '@/components/client/ClientPortalProvider'
+import { normaliseBinList } from '@/lib/binLabels'
 import { nextDay, setHours, setMinutes, startOfToday } from 'date-fns'
 import type { Day } from 'date-fns'
 
@@ -41,10 +42,7 @@ const normaliseId = (value: string | number | null | undefined): string | null =
 const createJobFromPayload = (payload: any, fallbackAccountId: string | null): Job | null => {
   if (!payload) return null
   const scheduledAt = computeNextOccurrence(payload.day_of_week ?? null)
-  const bins =
-    typeof payload.bins === 'string'
-      ? payload.bins.split(',').map((value: string) => value.trim())
-      : []
+  const bins = normaliseBinList(payload.bins)
   const propertyId = normaliseId(payload.property_id)
   const accountId = normaliseId(payload.account_id) ?? fallbackAccountId ?? 'unknown'
   return {

--- a/lib/binLabels.ts
+++ b/lib/binLabels.ts
@@ -1,0 +1,31 @@
+export type BinLabel = 'Landfill' | 'Recycling' | 'Compost'
+
+const BIN_KEYWORDS: { label: BinLabel; keywords: string[] }[] = [
+  { label: 'Landfill', keywords: ['landfill', 'general', 'garbage', 'trash', 'rubbish', 'red'] },
+  { label: 'Recycling', keywords: ['recycling', 'commingled', 'co-mingled', 'yellow'] },
+  { label: 'Compost', keywords: ['compost', 'organic', 'food', 'green'] },
+]
+
+const titleCase = (value: string): string => value.replace(/\b\w/g, (match) => match.toUpperCase())
+
+export function formatBinLabel(rawValue: string): string | null {
+  if (typeof rawValue !== 'string') return null
+  const trimmed = rawValue.trim()
+  if (!trimmed) return null
+  const lower = trimmed.toLowerCase()
+  for (const { label, keywords } of BIN_KEYWORDS) {
+    if (keywords.some((keyword) => lower.includes(keyword))) {
+      return label
+    }
+  }
+  return titleCase(trimmed)
+}
+
+export function normaliseBinList(value: unknown): string[] {
+  if (!value) return []
+  const items = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : []
+  const normalised = items
+    .map((item) => formatBinLabel(String(item)))
+    .filter((item): item is string => Boolean(item))
+  return Array.from(new Set(normalised))
+}


### PR DESCRIPTION
## Summary
- add a shared bin label normalizer so client views always show Landfill, Recycling, or Compost
- filter live tracker jobs to the selected account while mapping bin data to the new labels
- update client property filters and dashboards to use Compost terminology consistently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df5163b9d4833283780aa4cc0a1036