### PR TITLE
Replace live tracker with property map summary

### DIFF
--- a/components/client/LiveTracker.tsx
+++ b/components/client/LiveTracker.tsx
@@ -1,52 +1,52 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { format } from 'date-fns'
 import { BoltIcon, MapIcon, UserGroupIcon } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
-import { useClientPortal, computeEtaLabel } from './ClientPortalProvider'
+import { useClientPortal, computeEtaLabel, type Job } from './ClientPortalProvider'
 import { TrackerMap } from './TrackerMap'
 import { useRealtimeJobs } from '@/hooks/useRealtimeJobs'
 
-const STEPS: { key: 'scheduled' | 'en_route' | 'on_site' | 'completed'; label: string; description: string }[] = [
-  { key: 'scheduled', label: 'Scheduled', description: 'Collection booked and confirmed.' },
-  { key: 'en_route', label: 'En route', description: 'Crew is on the way.' },
-  { key: 'on_site', label: 'On site', description: 'Servicing bins now.' },
-  { key: 'completed', label: 'Completed', description: 'Job is wrapped up.' },
-]
-
-function Stepper({ status }: { status: typeof STEPS[number]['key'] }) {
-  const activeIndex = STEPS.findIndex((step) => step.key === status)
-
-  return (
-    <ol className="relative flex w-full flex-col gap-4 md:flex-row md:items-center">
-      {STEPS.map((step, index) => {
-        const isCompleted = index <= activeIndex
-        return (
-          <li key={step.key} className="flex flex-1 items-center gap-3">
-            <span
-              className={clsx(
-                'flex h-10 w-10 items-center justify-center rounded-full border-2 text-sm font-semibold transition',
-                isCompleted ? 'border-binbird-red bg-binbird-red text-white' : 'border-white/20 text-white/40',
-              )}
-            >
-              {index + 1}
-            </span>
-            <div>
-              <p className={clsx('text-sm font-semibold', isCompleted ? 'text-white' : 'text-white/60')}>{step.label}</p>
-              <p className="text-xs text-white/40">{step.description}</p>
-            </div>
-            {index < STEPS.length - 1 && <div className="hidden flex-1 border-b border-dashed border-white/10 md:block" />}
-          </li>
-        )
-      })}
-    </ol>
-  )
+const STATUS_META: Record<Job['status'], { label: string; badgeClassName: string }> = {
+  scheduled: {
+    label: 'Scheduled',
+    badgeClassName: 'border-amber-500/30 bg-amber-500/10 text-amber-200',
+  },
+  en_route: {
+    label: 'En route',
+    badgeClassName: 'border-sky-500/30 bg-sky-500/10 text-sky-200',
+  },
+  on_site: {
+    label: 'On site',
+    badgeClassName: 'border-rose-500/30 bg-rose-500/10 text-rose-200',
+  },
+  completed: {
+    label: 'Completed',
+    badgeClassName: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200',
+  },
+  skipped: {
+    label: 'Skipped',
+    badgeClassName: 'border-slate-500/30 bg-slate-500/10 text-slate-200',
+  },
 }
 
 export function LiveTracker() {
-  const { jobs, properties, selectedAccount, upsertJob, refreshJobs, jobsLoading } = useClientPortal()
-  const activeJobs = useMemo(() => jobs.filter((job) => job.status !== 'completed' && job.status !== 'skipped'), [jobs])
+  const {
+    jobs,
+    properties,
+    selectedAccount,
+    upsertJob,
+    refreshJobs,
+    refreshProperties,
+    jobsLoading,
+  } = useClientPortal()
+
+  const activeJobs = useMemo(
+    () => jobs.filter((job) => job.status !== 'completed' && job.status !== 'skipped'),
+    [jobs],
+  )
+
   const realtimePropertyIds = useMemo(
     () =>
       Array.from(
@@ -73,70 +73,93 @@ export function LiveTracker() {
     [activeJobs],
   )
 
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([refreshProperties(), refreshJobs()])
+  }, [refreshJobs, refreshProperties])
+
   return (
     <div className="space-y-6 text-white">
       <section className="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-inner shadow-black/30">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-white">Live service tracker</h3>
-            <p className="text-sm text-white/60">Stay close to the crew with live location and progress updates.</p>
+            <h3 className="text-lg font-semibold text-white">Property map</h3>
+            <p className="text-sm text-white/60">Explore every location we service for your account.</p>
           </div>
-          <button
-            type="button"
-            onClick={() => refreshJobs()}
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:text-white"
-          >
-            <BoltIcon className="h-5 w-5" /> Refresh now
-          </button>
         </header>
         <div className="mt-6">
-          <TrackerMap jobs={activeJobs} properties={properties} />
+          <TrackerMap properties={properties} />
         </div>
       </section>
 
       <section className="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-inner shadow-black/30">
-        <header className="flex items-center gap-3 text-sm text-white/60">
-          <UserGroupIcon className="h-5 w-5" />
-          {todaysJobs.length} active job{todaysJobs.length === 1 ? '' : 's'} today
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3 text-sm text-white/60">
+            <UserGroupIcon className="h-5 w-5" />
+            {todaysJobs.length} active job{todaysJobs.length === 1 ? '' : 's'} today
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              void handleRefresh()
+            }}
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:text-white"
+          >
+            <BoltIcon className="h-5 w-5" /> Refresh data
+          </button>
         </header>
         {jobsLoading ? (
           <div className="flex min-h-[160px] items-center justify-center text-white/60">
             <span className="flex items-center gap-3">
               <span className="h-2 w-2 animate-ping rounded-full bg-binbird-red" />
-              Loading live jobs…
+              Loading active jobs…
             </span>
           </div>
         ) : todaysJobs.length === 0 ? (
           <div className="mt-6 rounded-3xl border border-dashed border-white/20 bg-black/40 px-6 py-12 text-center text-white/60">
-            <h4 className="text-lg font-semibold text-white">No live jobs yet</h4>
-            <p className="mt-2 text-sm">
-              Your next service will appear here once the crew begins their route.
-            </p>
+            <h4 className="text-lg font-semibold text-white">No active jobs today</h4>
+            <p className="mt-2 text-sm">We’ll list your next service here once the crew is on the schedule.</p>
           </div>
         ) : (
           <div className="mt-6 space-y-6">
-            {todaysJobs.map((job) => (
-              <article key={job.id} className="rounded-3xl border border-white/10 bg-black/50 p-5">
-                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                  <div>
-                    <p className="text-sm uppercase tracking-wide text-white/50">{job.propertyName}</p>
-                    <h3 className="text-xl font-semibold text-white">{computeEtaLabel(job)}</h3>
-                    <p className="text-sm text-white/60">
-                      Status: {job.status.replace('_', ' ')}
-                      {job.jobType ? ` · ${job.jobType.replace('_', ' ')}` : ''}
-                      {job.bins && job.bins.length > 0 ? ` · ${job.bins.join(', ')}` : ''}
-                    </p>
+            {todaysJobs.map((job) => {
+              const status = STATUS_META[job.status]
+              return (
+                <article key={job.id} className="rounded-3xl border border-white/10 bg-black/50 p-5">
+                  <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="text-sm uppercase tracking-wide text-white/50">{job.propertyName}</p>
+                      <h3 className="text-xl font-semibold text-white">{computeEtaLabel(job)}</h3>
+                      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-white/60">
+                        <span
+                          className={clsx(
+                            'inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide',
+                            status.badgeClassName,
+                          )}
+                        >
+                          {status.label}
+                        </span>
+                        {job.jobType ? (
+                          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-wide text-white/70">
+                            {job.jobType.replace('_', ' ')}
+                          </span>
+                        ) : null}
+                        {job.bins && job.bins.length > 0 ? (
+                          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-wide text-white/70">
+                            {job.bins.join(', ')}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3 text-sm text-white/60">
+                      <MapIcon className="h-5 w-5" /> Scheduled {format(new Date(job.scheduledAt), 'p')}
+                    </div>
                   </div>
-                  <div className="flex items-center gap-3 text-sm text-white/60">
-                    <MapIcon className="h-5 w-5" />
-                    Updated {format(new Date(job.scheduledAt), 'p')}
-                  </div>
-                </div>
-                <div className="mt-6">
-                  <Stepper status={job.status as (typeof STEPS)[number]['key']} />
-                </div>
-              </article>
-            ))}
+                  {job.notes ? (
+                    <p className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-3 text-sm text-white/70">{job.notes}</p>
+                  ) : null}
+                </article>
+              )
+            })}
           </div>
         )}
       </section>

--- a/components/client/TrackerMap.tsx
+++ b/components/client/TrackerMap.tsx
@@ -2,8 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { GoogleMap, MarkerF, OverlayViewF, useLoadScript } from '@react-google-maps/api'
-import type { Job, Property } from './ClientPortalProvider'
-import { computeEtaLabel } from './ClientPortalProvider'
+import type { Property } from './ClientPortalProvider'
 import { useMapSettings } from '@/components/Context/MapSettingsContext'
 import { darkMapStyle, lightMapStyle, satelliteMapStyle } from '@/lib/mapStyle'
 
@@ -12,31 +11,16 @@ function normalisePropertyCoordinate(value: number | null | undefined): number |
   return Number.isFinite(value) ? value : null
 }
 
-type MarkerDescriptor = {
-  job: Job
-  property?: Property
-  position: google.maps.LatLngLiteral
-}
-
 type PropertyMarkerDescriptor = {
   property: Property
   position: google.maps.LatLngLiteral
 }
 
 export type TrackerMapProps = {
-  jobs: Job[]
   properties: Property[]
 }
 
 const FALLBACK_CENTER: google.maps.LatLngLiteral = { lat: -33.865143, lng: 151.2099 }
-
-const STATUS_COLOURS: Record<Job['status'], string> = {
-  scheduled: '#f59e0b',
-  en_route: '#3b82f6',
-  on_site: '#ef4444',
-  completed: '#22c55e',
-  skipped: '#9ca3af',
-}
 
 const MAP_STYLE_LOOKUP = {
   Dark: darkMapStyle,
@@ -44,7 +28,12 @@ const MAP_STYLE_LOOKUP = {
   Satellite: satelliteMapStyle,
 } as const
 
-export function TrackerMap({ jobs, properties }: TrackerMapProps) {
+function formatPropertyAddress(property: Property) {
+  const parts = [property.addressLine, property.suburb, property.city].filter(Boolean)
+  return parts.join(', ')
+}
+
+export function TrackerMap({ properties }: TrackerMapProps) {
   const { mapStylePref } = useMapSettings()
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
   const { isLoaded, loadError } = useLoadScript({
@@ -53,71 +42,33 @@ export function TrackerMap({ jobs, properties }: TrackerMapProps) {
   })
   const [map, setMap] = useState<google.maps.Map | null>(null)
 
-  const jobMarkers = useMemo<MarkerDescriptor[]>(() => {
-    const propertyById = new Map(properties.map((property) => [property.id, property]))
-    const markers: MarkerDescriptor[] = []
-
-    for (const job of jobs) {
-      const property = job.propertyId ? propertyById.get(job.propertyId) : undefined
-      const latitude = normalisePropertyCoordinate(job.lastLatitude ?? property?.latitude)
-      const longitude = normalisePropertyCoordinate(job.lastLongitude ?? property?.longitude)
-
-      if (latitude === null || longitude === null) continue
-
-      markers.push({
-        job,
-        property,
-        position: { lat: latitude, lng: longitude },
-      })
-    }
-
-    return markers
-  }, [jobs, properties])
-
-  const jobPropertyIds = useMemo(() => {
-    const ids = new Set<string>()
-    jobMarkers.forEach((marker) => {
-      if (marker.property?.id) {
-        ids.add(marker.property.id)
-      }
-    })
-    return ids
-  }, [jobMarkers])
-
-  const idlePropertyMarkers = useMemo<PropertyMarkerDescriptor[]>(() => {
+  const propertyMarkers = useMemo<PropertyMarkerDescriptor[]>(() => {
     return properties
-      .filter((property) => {
-        if (!property.id || jobPropertyIds.has(property.id)) return false
+      .map((property) => {
         const latitude = normalisePropertyCoordinate(property.latitude)
         const longitude = normalisePropertyCoordinate(property.longitude)
-        return latitude !== null && longitude !== null
-      })
-      .map((property) => ({
-        property,
-        position: {
-          lat: normalisePropertyCoordinate(property.latitude) as number,
-          lng: normalisePropertyCoordinate(property.longitude) as number,
-        },
-      }))
-  }, [jobPropertyIds, properties])
 
-  const anchorPoints = useMemo(() => {
-    if (jobMarkers.length > 0) return jobMarkers.map((marker) => marker.position)
-    if (idlePropertyMarkers.length > 0) return idlePropertyMarkers.map((marker) => marker.position)
-    return []
-  }, [idlePropertyMarkers, jobMarkers])
+        if (latitude === null || longitude === null) return null
+
+        return {
+          property,
+          position: { lat: latitude, lng: longitude },
+        }
+      })
+      .filter((marker): marker is PropertyMarkerDescriptor => Boolean(marker))
+  }, [properties])
 
   const mapCenter = useMemo(() => {
-    if (anchorPoints.length === 0) return FALLBACK_CENTER
-    const aggregate = anchorPoints.reduce(
-      (acc, point) => ({ lat: acc.lat + point.lat, lng: acc.lng + point.lng }),
+    if (propertyMarkers.length === 0) return FALLBACK_CENTER
+    const aggregate = propertyMarkers.reduce(
+      (acc, point) => ({ lat: acc.lat + point.position.lat, lng: acc.lng + point.position.lng }),
       { lat: 0, lng: 0 },
     )
     return {
-      lat: aggregate.lat / anchorPoints.length,
-      lng: aggregate.lng / anchorPoints.length,
+      lat: aggregate.lat / propertyMarkers.length,
+      lng: aggregate.lng / propertyMarkers.length,
     }
-  }, [anchorPoints])
+  }, [propertyMarkers])
 
   const mapOptions = useMemo(
     () => ({
@@ -135,7 +86,7 @@ export function TrackerMap({ jobs, properties }: TrackerMapProps) {
   useEffect(() => {
     if (!map) return
 
-    if (anchorPoints.length === 0) {
+    if (propertyMarkers.length === 0) {
       map.setCenter(FALLBACK_CENTER)
       map.setZoom(11)
       return
@@ -143,44 +94,25 @@ export function TrackerMap({ jobs, properties }: TrackerMapProps) {
 
     if (typeof window === 'undefined' || !window.google?.maps) return
 
-    if (anchorPoints.length === 1) {
-      map.panTo(anchorPoints[0]!)
+    if (propertyMarkers.length === 1) {
+      map.panTo(propertyMarkers[0]!.position)
       map.setZoom(14)
       return
     }
 
     const bounds = new window.google.maps.LatLngBounds()
-    anchorPoints.forEach((point) => bounds.extend(point))
+    propertyMarkers.forEach((marker) => bounds.extend(marker.position))
     map.fitBounds(bounds, 48)
-  }, [anchorPoints, map])
-
-  const statusIcons = useMemo(() => {
-    if (!isLoaded || typeof window === 'undefined' || !window.google?.maps) return null
-    const entries = Object.entries(STATUS_COLOURS).map(
-      ([status, colour]) =>
-        [
-          status as Job['status'],
-          {
-            path: window.google.maps.SymbolPath.CIRCLE,
-            scale: 10,
-            fillColor: colour,
-            fillOpacity: 1,
-            strokeColor: '#ffffff',
-            strokeWeight: 2,
-          } as google.maps.Symbol,
-        ] as const,
-    )
-    return new Map<Job['status'], google.maps.Symbol>(entries)
-  }, [isLoaded])
+  }, [map, propertyMarkers])
 
   const propertyIcon = useMemo(() => {
     if (!isLoaded || typeof window === 'undefined' || !window.google?.maps) return undefined
     return {
       path: window.google.maps.SymbolPath.CIRCLE,
-      scale: 6,
-      fillColor: '#6b7280',
-      fillOpacity: 0.9,
-      strokeColor: '#111827',
+      scale: 8,
+      fillColor: '#ef4444',
+      fillOpacity: 0.95,
+      strokeColor: '#ffffff',
       strokeWeight: 2,
     } as google.maps.Symbol
   }, [isLoaded])
@@ -197,14 +129,14 @@ export function TrackerMap({ jobs, properties }: TrackerMapProps) {
     <div className="relative h-80 overflow-hidden rounded-3xl border border-white/10 bg-black/60">
       {!apiKey ? (
         <div className="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-white/60">
-          Add a Google Maps API key to enable live location tracking.
+          Add a Google Maps API key to view your properties on the map.
         </div>
       ) : loadError ? (
         <div className="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-white/60">
           We couldn’t load the map right now. Please refresh to try again.
         </div>
       ) : !isLoaded ? (
-        <div className="absolute inset-0 flex items-center justify-center text-white/60">Loading live map…</div>
+        <div className="absolute inset-0 flex items-center justify-center text-white/60">Loading map…</div>
       ) : (
         <>
           <GoogleMap
@@ -215,35 +147,7 @@ export function TrackerMap({ jobs, properties }: TrackerMapProps) {
             onLoad={handleMapLoad}
             onUnmount={handleMapUnmount}
           >
-            {jobMarkers.map((marker) => (
-              <MarkerF
-                key={`job-${marker.job.id}`}
-                position={marker.position}
-                icon={statusIcons?.get(marker.job.status)}
-                title={marker.property?.name ?? marker.job.propertyName}
-                zIndex={marker.job.status === 'completed' ? 2 : 3}
-              />
-            ))}
-            {jobMarkers.map((marker) => (
-              <OverlayViewF
-                key={`overlay-${marker.job.id}`}
-                position={marker.position}
-                mapPaneName="overlayMouseTarget"
-              >
-                <div className="pointer-events-none -translate-x-1/2 -translate-y-3">
-                  <div className="rounded-2xl border border-white/20 bg-black/80 px-3 py-2 text-xs text-white/80 shadow-lg shadow-black/40">
-                    <p className="text-sm font-semibold text-white">
-                      {marker.property?.name ?? marker.job.propertyName}
-                    </p>
-                    <p className="text-[10px] uppercase tracking-wide text-white/50">
-                      {marker.job.status.replace('_', ' ')}
-                    </p>
-                    <p className="text-xs text-white/70">{computeEtaLabel(marker.job)}</p>
-                  </div>
-                </div>
-              </OverlayViewF>
-            ))}
-            {idlePropertyMarkers.map((marker) => (
+            {propertyMarkers.map((marker) => (
               <MarkerF
                 key={`property-${marker.property.id}`}
                 position={marker.position}
@@ -252,10 +156,24 @@ export function TrackerMap({ jobs, properties }: TrackerMapProps) {
                 zIndex={1}
               />
             ))}
+            {propertyMarkers.map((marker) => (
+              <OverlayViewF
+                key={`overlay-${marker.property.id}`}
+                position={marker.position}
+                mapPaneName="overlayMouseTarget"
+              >
+                <div className="pointer-events-none -translate-x-1/2 -translate-y-3">
+                  <div className="rounded-2xl border border-white/20 bg-black/80 px-3 py-2 text-xs text-white/80 shadow-lg shadow-black/40">
+                    <p className="text-sm font-semibold text-white">{marker.property.name}</p>
+                    <p className="text-[11px] text-white/70">{formatPropertyAddress(marker.property)}</p>
+                  </div>
+                </div>
+              </OverlayViewF>
+            ))}
           </GoogleMap>
-          {jobMarkers.length === 0 && (
+          {propertyMarkers.length === 0 && (
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-white/60">
-              Location data will appear here once your crew heads out.
+              Add latitude and longitude to your properties to see them appear on the map.
             </div>
           )}
         </>


### PR DESCRIPTION
## Summary
- replace the live tracker header with a property map overview and remove the status stepper
- simplify the tracker map to plot all client properties and label each pin with its address
- refresh the active jobs list styling with status badges and supporting metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df6ad68c0083329a82c0dec4d30f3a