### PR TITLE
Rename landfill terminology to garbage

### DIFF
--- a/__tests__/JobHistoryTable.test.tsx
+++ b/__tests__/JobHistoryTable.test.tsx
@@ -26,7 +26,7 @@ const jobs: Job[] = [
     lastLongitude: null,
     notes: null,
     jobType: 'bring_in',
-    bins: ['Landfill', 'Recycling'],
+    bins: ['Garbage', 'Recycling'],
   },
 ]
 

--- a/__tests__/computeEtaLabel.test.ts
+++ b/__tests__/computeEtaLabel.test.ts
@@ -18,7 +18,7 @@ const baseJob: Job = {
   lastLongitude: null,
   notes: null,
   jobType: 'bring_in',
-  bins: ['Landfill'],
+  bins: ['Garbage'],
 }
 
 describe('computeEtaLabel', () => {

--- a/app/ops/clients/page.tsx
+++ b/app/ops/clients/page.tsx
@@ -40,7 +40,7 @@ const describeBinFrequency = (
 const deriveBinsThisWeek = (row: ClientListRow): string => {
   const bins = [
 
-    describeBinFrequency('Landfill', row.red_freq, row.red_flip),
+    describeBinFrequency('Garbage', row.red_freq, row.red_flip),
     describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip),
     describeBinFrequency('Organic', row.green_freq, row.green_flip),
   ].filter(Boolean) as string[]

--- a/app/ops/generate/page.tsx
+++ b/app/ops/generate/page.tsx
@@ -112,7 +112,7 @@ const deriveClientName = (row: ClientListRow): string =>
 
 const buildBinsSummary = (row: ClientListRow): string | null => {
   const bins = [
-    describeBinFrequency('Landfill', row.red_freq, row.red_flip),
+    describeBinFrequency('Garbage', row.red_freq, row.red_flip),
     describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip),
     describeBinFrequency('Organic', row.green_freq, row.green_flip),
   ].filter(Boolean) as string[]

--- a/components/client/ClientPortalProvider.tsx
+++ b/components/client/ClientPortalProvider.tsx
@@ -290,7 +290,7 @@ const toProperty = (row: ClientListRow): Property => {
   const [addressLine, suburbRaw = ''] = (row.address ?? '').split(',')
   const suburb = suburbRaw.trim()
   const binTypes = [
-    describeBinFrequency('Landfill', row.red_freq, row.red_flip),
+    describeBinFrequency('Garbage', row.red_freq, row.red_flip),
     describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip),
     describeBinFrequency('Compost', row.green_freq, row.green_flip),
   ].filter(Boolean) as string[]

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -26,7 +26,7 @@ function matchesFilters(property: Property, filters: PropertyFilterState) {
     const hasBinType = property.binTypes.some((bin) => {
       const label = formatBinLabel(bin)
       if (!label) return false
-      if (filters.binType === 'landfill') return label === 'Landfill'
+      if (filters.binType === 'garbage') return label === 'Garbage'
       if (filters.binType === 'recycling') return label === 'Recycling'
       return label === 'Compost'
     })

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -9,13 +9,13 @@ import { formatBinLabel } from '@/lib/binLabels'
 export type PropertyFilterState = {
   search: string
   status: 'all' | 'active' | 'paused'
-  binType: 'all' | 'landfill' | 'recycling' | 'compost'
+  binType: 'all' | 'garbage' | 'recycling' | 'compost'
   groupBy: 'city' | 'status'
 }
 
 const BIN_LABELS: Record<PropertyFilterState['binType'], string> = {
   all: 'All bins',
-  landfill: 'Landfill',
+  garbage: 'Garbage',
   recycling: 'Recycling',
   compost: 'Compost',
 }
@@ -40,11 +40,11 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
           const label = formatBinLabel(bin)
           if (label === 'Recycling') accumulator.recycling += 1
           else if (label === 'Compost') accumulator.compost += 1
-          else if (label === 'Landfill') accumulator.landfill += 1
+          else if (label === 'Garbage') accumulator.garbage += 1
         })
         return accumulator
       },
-      { landfill: 0, recycling: 0, compost: 0 },
+      { garbage: 0, recycling: 0, compost: 0 },
     )
 
     return totalBins
@@ -119,8 +119,8 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
       </div>
       <dl className="mt-6 grid gap-4 sm:grid-cols-3">
         <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-          <dt className="text-xs uppercase tracking-wide text-white/50">Landfill bins</dt>
-          <dd className="mt-1 text-2xl font-semibold">{totals.landfill}</dd>
+          <dt className="text-xs uppercase tracking-wide text-white/50">Garbage bins</dt>
+          <dd className="mt-1 text-2xl font-semibold">{totals.garbage}</dd>
         </div>
         <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
           <dt className="text-xs uppercase tracking-wide text-white/50">Recycling bins</dt>

--- a/lib/binLabels.ts
+++ b/lib/binLabels.ts
@@ -1,7 +1,7 @@
-export type BinLabel = 'Landfill' | 'Recycling' | 'Compost'
+export type BinLabel = 'Garbage' | 'Recycling' | 'Compost'
 
 const BIN_KEYWORDS: { label: BinLabel; keywords: string[] }[] = [
-  { label: 'Landfill', keywords: ['landfill', 'general', 'garbage', 'trash', 'rubbish', 'red'] },
+  { label: 'Garbage', keywords: ['garbage', 'landfill', 'general', 'trash', 'rubbish', 'red'] },
   { label: 'Recycling', keywords: ['recycling', 'commingled', 'co-mingled', 'yellow'] },
   { label: 'Compost', keywords: ['compost', 'organic', 'food', 'green'] },
 ]


### PR DESCRIPTION
## Summary
- update client- and ops-facing pages to display Garbage instead of Landfill for red-bin services
- normalise bin labels to return the Garbage label and refresh related unit tests

## Testing
- npm run test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df6ae8c8a48332ba12283044fc12f9