### PR TITLE
Remove unused property filters

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -5,13 +5,10 @@ import { format } from 'date-fns'
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import type { Property } from './ClientPortalProvider'
 import { PropertyFilters, type PropertyFilterState } from './PropertyFilters'
-import { formatBinLabel } from '@/lib/binLabels'
 
 const DEFAULT_FILTERS: PropertyFilterState = {
   search: '',
   status: 'all',
-  binType: 'all',
-  groupBy: 'city',
 }
 
 function matchesFilters(property: Property, filters: PropertyFilterState) {
@@ -22,28 +19,10 @@ function matchesFilters(property: Property, filters: PropertyFilterState) {
       return false
     }
   }
-  if (filters.binType !== 'all') {
-    const hasBinType = property.binTypes.some((bin) => {
-      const label = formatBinLabel(bin)
-      if (!label) return false
-      if (filters.binType === 'garbage') return label === 'Garbage'
-      if (filters.binType === 'recycling') return label === 'Recycling'
-      return label === 'Compost'
-    })
-    if (!hasBinType) return false
-  }
   return true
 }
 
-function groupProperties(properties: Property[], filters: PropertyFilterState) {
-  if (filters.groupBy === 'status') {
-    return properties.reduce<Record<string, Property[]>>((groups, property) => {
-      const key = property.status
-      groups[key] = groups[key] ? [...groups[key], property] : [property]
-      return groups
-    }, {})
-  }
-
+function groupProperties(properties: Property[]) {
   return properties.reduce<Record<string, Property[]>>((groups, property) => {
     const key = property.city || 'Unassigned'
     groups[key] = groups[key] ? [...groups[key], property] : [property]
@@ -60,7 +39,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
   const [filters, setFilters] = useState<PropertyFilterState>(DEFAULT_FILTERS)
 
   const filtered = useMemo(() => properties.filter((property) => matchesFilters(property, filters)), [properties, filters])
-  const grouped = useMemo(() => groupProperties(filtered, filters), [filtered, filters])
+  const grouped = useMemo(() => groupProperties(filtered), [filtered])
 
   return (
     <div className="space-y-6 text-white">

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -9,15 +9,6 @@ import { formatBinLabel } from '@/lib/binLabels'
 export type PropertyFilterState = {
   search: string
   status: 'all' | 'active' | 'paused'
-  binType: 'all' | 'garbage' | 'recycling' | 'compost'
-  groupBy: 'city' | 'status'
-}
-
-const BIN_LABELS: Record<PropertyFilterState['binType'], string> = {
-  all: 'All bins',
-  garbage: 'Garbage',
-  recycling: 'Recycling',
-  compost: 'Compost',
 }
 
 const STATUS_LABELS: Record<PropertyFilterState['status'], string> = {
@@ -60,7 +51,7 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
         <FunnelIcon className="h-5 w-5" />
         <span>Filter properties</span>
       </div>
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2">
         <label className="flex flex-col gap-2 text-sm">
           <span className="text-white/60">Search</span>
           <input
@@ -90,31 +81,6 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
               </button>
             ))}
           </div>
-        </label>
-        <label className="flex flex-col gap-2 text-sm">
-          <span className="text-white/60">Bin type</span>
-          <select
-            value={filters.binType}
-            onChange={(event) => update({ binType: event.target.value as PropertyFilterState['binType'] })}
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
-          >
-            {(Object.keys(BIN_LABELS) as PropertyFilterState['binType'][]).map((bin) => (
-              <option key={bin} value={bin} className="bg-black">
-                {BIN_LABELS[bin]}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col gap-2 text-sm">
-          <span className="text-white/60">Group by</span>
-          <select
-            value={filters.groupBy}
-            onChange={(event) => update({ groupBy: event.target.value as PropertyFilterState['groupBy'] })}
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
-          >
-            <option value="city">City</option>
-            <option value="status">Status</option>
-          </select>
         </label>
       </div>
       <dl className="mt-6 grid gap-4 sm:grid-cols-3">


### PR DESCRIPTION
## Summary
- remove the bin type and group by filters from the property filters panel
- simplify the property dashboard filter state and grouping logic to match the remaining controls

## Testing
- npm run test *(fails: __tests__/JobHistoryTable.test.tsx > JobHistoryTable > renders job rows)*

------
https://chatgpt.com/codex/tasks/task_e_68e049a8ffe08332926be2a8d3ab3a16