### PR TITLE
Streamline tracker popover address layout

### DIFF
--- a/components/client/TrackerMap.tsx
+++ b/components/client/TrackerMap.tsx
@@ -29,8 +29,27 @@ const MAP_STYLE_LOOKUP = {
 } as const
 
 function formatPropertyAddress(property: Property) {
-  const parts = [property.addressLine, property.suburb, property.city].filter(Boolean)
-  return parts.join(', ')
+  const addressLine = property.addressLine?.trim() || property.name?.trim() || 'Property'
+  const locationParts = [property.suburb, property.city]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+  const uniqueLocationParts = locationParts.filter((part, index) => {
+    return locationParts.findIndex((candidate) => candidate.toLowerCase() === part.toLowerCase()) === index
+  })
+  const locationLine = uniqueLocationParts.join(', ')
+  return { addressLine, locationLine }
+}
+
+function AddressPopoverContent({ property }: { property: Property }) {
+  const { addressLine, locationLine } = formatPropertyAddress(property)
+  return (
+    <div className="px-3 py-2 text-[11px] text-white">
+      <div className="flex flex-col gap-1 text-left">
+        <p className="font-semibold text-[var(--accent)]">{addressLine}</p>
+        {locationLine ? <p className="text-white/80">{locationLine}</p> : null}
+      </div>
+    </div>
+  )
 }
 
 export function TrackerMap({ properties }: TrackerMapProps) {
@@ -41,6 +60,7 @@ export function TrackerMap({ properties }: TrackerMapProps) {
     googleMapsApiKey: apiKey ?? '',
   })
   const [map, setMap] = useState<google.maps.Map | null>(null)
+  const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null)
 
   const propertyMarkers = useMemo<PropertyMarkerDescriptor[]>(() => {
     return properties
@@ -107,28 +127,24 @@ export function TrackerMap({ properties }: TrackerMapProps) {
 
   const propertyIcon = useMemo(() => {
     if (!isLoaded || typeof window === 'undefined' || !window.google?.maps) return undefined
+    const accent = '#ff5757'
     const svg = encodeURIComponent(`<?xml version="1.0" encoding="UTF-8"?>
-      <svg width="52" height="70" viewBox="0 0 52 70" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="48" height="66" viewBox="0 0 48 66" fill="none" xmlns="http://www.w3.org/2000/svg">
         <defs>
-          <linearGradient id="pinGradient" x1="26" y1="0" x2="26" y2="70" gradientUnits="userSpaceOnUse">
-            <stop offset="0%" stop-color="#facc15"/>
-            <stop offset="45%" stop-color="#f97316"/>
-            <stop offset="100%" stop-color="#ef4444"/>
-          </linearGradient>
-          <filter id="pinShadow" x="0" y="0" width="52" height="70" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-            <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="rgba(0,0,0,0.35)"/>
+          <filter id="pinShadow" x="0" y="0" width="48" height="66" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feDropShadow dx="0" dy="5" stdDeviation="5" flood-color="rgba(255, 87, 87, 0.32)"/>
           </filter>
         </defs>
         <g filter="url(#pinShadow)">
-          <path d="M26 0C14.9543 0 6 8.95431 6 20C6 33.2 26 62 26 62C26 62 46 33.2 46 20C46 8.95431 37.0457 0 26 0Z" fill="url(#pinGradient)"/>
-          <circle cx="26" cy="20" r="9" fill="white" fill-opacity="0.9"/>
-          <circle cx="26" cy="20" r="5" fill="#0f172a" fill-opacity="0.8"/>
+          <path d="M24 0C13.5066 0 5 8.50659 5 19C5 31.98 24 58 24 58C24 58 43 31.98 43 19C43 8.50659 34.4934 0 24 0Z" fill="${accent}"/>
+          <circle cx="24" cy="18" r="8.5" fill="#0b0d12" fill-opacity="0.92"/>
+          <circle cx="24" cy="18" r="4.5" fill="white" fill-opacity="0.92"/>
         </g>
       </svg>`)
     return {
       url: `data:image/svg+xml;charset=UTF-8,${svg}`,
-      scaledSize: new window.google.maps.Size(40, 54),
-      anchor: new window.google.maps.Point(20, 54),
+      scaledSize: new window.google.maps.Size(36, 52),
+      anchor: new window.google.maps.Point(18, 52),
     } as google.maps.Icon
   }, [isLoaded])
 
@@ -138,6 +154,10 @@ export function TrackerMap({ properties }: TrackerMapProps) {
 
   const handleMapUnmount = useCallback(() => {
     setMap(null)
+  }, [])
+
+  const handleMapClick = useCallback(() => {
+    setSelectedPropertyId(null)
   }, [])
 
   return (
@@ -161,6 +181,7 @@ export function TrackerMap({ properties }: TrackerMapProps) {
             zoom={12}
             onLoad={handleMapLoad}
             onUnmount={handleMapUnmount}
+            onClick={handleMapClick}
           >
             {propertyMarkers.map((marker) => (
               <MarkerF
@@ -168,30 +189,57 @@ export function TrackerMap({ properties }: TrackerMapProps) {
                 position={marker.position}
                 icon={propertyIcon}
                 title={marker.property.name}
+                onClick={() => {
+                  setSelectedPropertyId((current) =>
+                    current === marker.property.id ? null : marker.property.id,
+                  )
+                }}
                 zIndex={1}
               />
             ))}
-            {propertyMarkers.map((marker) => (
-              <OverlayViewF
-                key={`overlay-${marker.property.id}`}
-                position={marker.position}
-                mapPaneName="overlayMouseTarget"
-              >
-                <div className="pointer-events-none -translate-x-1/2 -translate-y-5">
-                  <div className="flex flex-col items-center">
-                    <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/80 text-xs shadow-lg shadow-black/40">
-                      <div className="bg-gradient-to-r from-amber-400/90 via-orange-500/80 to-rose-500/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-900">
-                        {marker.property.name}
-                      </div>
-                      <div className="px-3 py-2 text-[11px] text-white/70">
-                        <p className="leading-snug">{formatPropertyAddress(marker.property)}</p>
-                      </div>
+            {propertyMarkers.map((marker) => {
+              const isSelected = marker.property.id === selectedPropertyId
+              if (!isSelected) {
+                return (
+                  <OverlayViewF
+                    key={`halo-${marker.property.id}`}
+                    position={marker.position}
+                    mapPaneName="overlayMouseTarget"
+                  >
+                    <div className="pointer-events-none -translate-x-1/2 -translate-y-[58px]">
+                      <span className="relative block h-12 w-12">
+                        <span
+                          className="absolute inset-0 animate-pulse rounded-full"
+                          style={{ backgroundColor: 'rgba(255, 87, 87, 0.18)' }}
+                        />
+                      </span>
                     </div>
-                    <div className="-mt-1 h-3 w-3 rotate-45 border border-white/10 bg-black/80" />
+                  </OverlayViewF>
+                )
+              }
+
+              return (
+                <OverlayViewF
+                  key={`overlay-${marker.property.id}`}
+                  position={marker.position}
+                  mapPaneName="overlayMouseTarget"
+                  zIndex={2}
+                >
+                  <div
+                    className="pointer-events-auto"
+                    style={{ transform: 'translate(-50%, calc(-100% - 58px))' }}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <div className="flex flex-col items-center">
+                      <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#0b0d12]/90 text-xs shadow-[0_18px_40px_rgba(0,0,0,0.55)] backdrop-blur-sm">
+                        <AddressPopoverContent property={marker.property} />
+                      </div>
+                      <div className="-mt-1 h-3 w-3 rotate-45 border border-white/10 bg-[#0b0d12]/90" />
+                    </div>
                   </div>
-                </div>
-              </OverlayViewF>
-            ))}
+                </OverlayViewF>
+              )
+            })}
           </GoogleMap>
           {propertyMarkers.length === 0 && (
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-white/60">


### PR DESCRIPTION
## Summary
- restyle the tracker popover to show the accent address line with a deduplicated suburb/city detail
- remove the popover close control so only the requested address content appears above each marker

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e049719be48332bb27d73c356cbaa3