### PR TITLE
Guard staff proof logging with account context

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -275,6 +275,10 @@ export default function ProofPageContent() {
       alert("Please take a photo before marking the job done.");
       return;
     }
+    if (!job.account_id) {
+      alert("Unable to log completion: missing account identifier for job.");
+      return;
+    }
     setSubmitting(true);
     try {
       const { data: { user }, error: authError } = await supabase.auth.getUser();
@@ -297,6 +301,7 @@ export default function ProofPageContent() {
       const noteValue = staffNote.length ? staffNote : null;
       const { error: logErr } = await supabase.from("logs").insert({
         job_id: job.id,
+        account_id: job.account_id,
         client_name: job.client_name ?? null,
         address: job.address,
         task_type: job.job_type,


### PR DESCRIPTION
## Summary
- guard staff proof submissions when account context is missing
- include account identifiers when inserting staff proof logs to align with portal implementation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0e68664e883329587336ec443ff4b