### PR TITLE
Ensure proof logging uses account guard

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -275,7 +275,8 @@ export default function ProofPageContent() {
       alert("Please take a photo before marking the job done.");
       return;
     }
-    if (!job.account_id) {
+    const accountId = job.account_id;
+    if (!accountId) {
       alert("Unable to log completion: missing account identifier for job.");
       return;
     }
@@ -301,7 +302,7 @@ export default function ProofPageContent() {
       const noteValue = staffNote.length ? staffNote : null;
       const { error: logErr } = await supabase.from("logs").insert({
         job_id: job.id,
-        account_id: job.account_id,
+        account_id: accountId,
         client_name: job.client_name ?? null,
         address: job.address,
         task_type: job.job_type,


### PR DESCRIPTION
## Summary
- align the staff proof submission flow with SmartJobCard by guarding and reusing the job account id when inserting logs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1d0f486a483329fec4df4cde00362