### PR TITLE
Include account context when inserting staff logs

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -309,6 +309,7 @@ export default function ProofPageContent() {
         gps_acc: gpsData.acc ?? null,
         gps_time: gpsData.time ?? null,
         user_id: user.id,
+        account_id: job.account_id,
       });
       if (logErr) throw logErr;
       await supabase.from("jobs").update({ last_completed_on: dateStr }).eq("id", job.id);

--- a/components/UI/SmartJobCard.tsx
+++ b/components/UI/SmartJobCard.tsx
@@ -76,6 +76,7 @@ export default function SmartJobCard({
         gps_acc: position?.coords.accuracy ?? null,
         gps_time: position ? new Date(position.timestamp).toISOString() : null,
         user_id: user.id,
+        account_id: job.account_id,
       });
       if (logErr) throw logErr;
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -22,6 +22,7 @@ export type JobRecord = {
   address: string | null
   lat: number | null
   lng: number | null
+  account_id: string | null
   last_completed_on: string | null
   assigned_to: string | null
   day_of_week: string | null

--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -5,6 +5,7 @@ export type Job = {
   address: string;
   lat: number;
   lng: number;
+  account_id: string | null;
   job_type: "put_out" | "bring_in";
   bins: string | null;
   notes: string | null;
@@ -94,6 +95,7 @@ export function normalizeJob<T extends Partial<JobRecord>>(record: T): Job {
     address: normalizeString(record.address),
     lat: normalizeNumber(record.lat),
     lng: normalizeNumber(record.lng),
+    account_id: normalizeOptionalString(record.account_id),
     job_type: normalizeJobType(record.job_type),
     bins: normalizeOptionalString(record.bins),
     notes: normalizeOptionalString(record.notes),

--- a/lib/planned-run.ts
+++ b/lib/planned-run.ts
@@ -65,6 +65,10 @@ function normalizeJob(value: Job): Job {
     address: typeof value.address === "string" ? value.address : "",
     lat: Number.isFinite(value.lat) ? value.lat : 0,
     lng: Number.isFinite(value.lng) ? value.lng : 0,
+    account_id:
+      typeof value.account_id === "string" && value.account_id.trim().length
+        ? value.account_id
+        : null,
     job_type: value.job_type === "bring_in" ? "bring_in" : "put_out",
     bins: typeof value.bins === "string" ? value.bins : null,
     notes: typeof value.notes === "string" ? value.notes : null,


### PR DESCRIPTION
## Summary
- include `account_id` when staff proof submissions insert into `public.logs`
- propagate the account identifier through job normalization and planned run storage so it is available client-side

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1e285660c833292d3502f8766b8dc