### PR TITLE
Add shared Supabase provider for client auth sync

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { ReactNode } from "react";
 import "./globals.css";
 import { MapSettingsProvider } from "@/components/Context/MapSettingsContext";
+import { SupabaseProvider } from "@/components/providers/SupabaseProvider";
 
 export const metadata: Metadata = {
     title: "BinBird",
@@ -24,11 +25,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="h-full">
       <body className="min-h-screen bg-transparent text-white antialiased">
-        <MapSettingsProvider>
-          <div className="flex flex-col min-h-screen">
-            {children}
-          </div>
-        </MapSettingsProvider>
+        <SupabaseProvider>
+          <MapSettingsProvider>
+            <div className="flex flex-col min-h-screen">
+              {children}
+            </div>
+          </MapSettingsProvider>
+        </SupabaseProvider>
       </body>
     </html>
   );

--- a/components/providers/SupabaseProvider.tsx
+++ b/components/providers/SupabaseProvider.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const SupabaseContext = createContext<SupabaseClient | undefined>(undefined);
+
+export function SupabaseProvider({ children }: { children: ReactNode }) {
+  const supabase = useMemo(() => createClientComponentClient(), []);
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      fetch("/auth/callback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ event, session }),
+      });
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  return <SupabaseContext.Provider value={supabase}>{children}</SupabaseContext.Provider>;
+}
+
+export function useSupabase() {
+  const context = useContext(SupabaseContext);
+
+  if (!context) {
+    throw new Error("useSupabase must be used within a SupabaseProvider");
+  }
+
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a client SupabaseProvider that memoizes a single auth client and synchronizes sessions with the server
- wrap the root layout with the Supabase provider while keeping the existing map settings context inside

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c988606083329da63f7153f7b453