### PR TITLE
refactor: use shared supabase client hook

### DIFF
--- a/app/auth/reset/page.tsx
+++ b/app/auth/reset/page.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 export default function StaffResetPasswordPage() {
+  const supabase = useSupabase();
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "sent">("idle");
   const [error, setError] = useState<string | null>(null);
@@ -15,7 +16,6 @@ export default function StaffResetPasswordPage() {
     setError(null);
 
     try {
-      const supabase = createClientComponentClient();
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
         redirectTo: `${window.location.origin}/auth/reset/confirm`,
       });

--- a/app/auth/sign-in/SignInClient.tsx
+++ b/app/auth/sign-in/SignInClient.tsx
@@ -4,10 +4,11 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 export default function SignInClient() {
   const router = useRouter();
+  const supabase = useSupabase();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -29,8 +30,6 @@ export default function SignInClient() {
     setLoading(true);
 
     try {
-      const supabase = createClientComponentClient();
-
       const { error: signInError } = await supabase.auth.signInWithPassword({
         email,
         password,

--- a/app/auth/sign-up/SignUpClient.tsx
+++ b/app/auth/sign-up/SignUpClient.tsx
@@ -3,11 +3,11 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 export default function SignUpClient() {
   const router = useRouter();
-  const supabase = createClientComponentClient();
+  const supabase = useSupabase();
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { useState, useEffect } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 export default function SettingsPage() {
   const [navPref, setNavPref] = useState<"google" | "waze" | "apple">("google");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const supabase = createClientComponentClient();
+  const supabase = useSupabase();
 
   useEffect(() => {
     const stored = localStorage.getItem("navPref");

--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useSearchParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getLocalISODate } from "@/lib/date";
 import { normalizeJobs, type Job } from "@/lib/jobs";
 import { readRunSession, writeRunSession, type RunSessionRecord } from "@/lib/run-session";
 import { clearPlannedRun } from "@/lib/planned-run";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 const TRANSPARENT_PIXEL =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
@@ -103,7 +103,7 @@ async function prepareFileAsJpeg(originalFile: File, desiredName: string): Promi
 }
 
 export default function ProofPageContent() {
-  const supabase = useMemo(() => createClientComponentClient(), []);
+  const supabase = useSupabase();
   const params = useSearchParams();
   const router = useRouter();
 

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { GoogleMap, Marker, DirectionsRenderer, useLoadScript } from "@react-google-maps/api";
 import SettingsDrawer from "@/components/UI/SettingsDrawer";
 import { PortalLoadingScreen } from "@/components/UI/PortalLoadingScreen";
 import { darkMapStyle, lightMapStyle, satelliteMapStyle } from "@/lib/mapStyle";
 import { MapSettingsProvider, useMapSettings } from "@/components/Context/MapSettingsContext";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { normalizeJobs, type Job } from "@/lib/jobs";
 import { readPlannedRun } from "@/lib/planned-run";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 function RoutePageContent() {
-  const supabase = createClientComponentClient();
+  const supabase = useSupabase();
   const params = useSearchParams();
   const router = useRouter();
   const { mapStylePref, setMapStylePref, navPref, setNavPref } = useMapSettings();
@@ -58,7 +58,9 @@ function RoutePageContent() {
   // Load user settings from Supabase
   useEffect(() => {
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) return;
 
       const { data: profile, error } = await supabase
@@ -72,7 +74,7 @@ function RoutePageContent() {
         if (profile.nav_pref) setNavPref(profile.nav_pref);
       }
     })();
-  }, []);
+  }, [setMapStylePref, setNavPref, supabase]);
 
   // Parse jobs + start
   useEffect(() => {

--- a/app/staff/run/completed/page.tsx
+++ b/app/staff/run/completed/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { MapSettingsProvider } from "@/components/Context/MapSettingsContext";
 import SettingsDrawer from "@/components/UI/SettingsDrawer";
 import {
@@ -11,6 +10,7 @@ import {
   RunSessionRecord,
 } from "@/lib/run-session";
 import { clearPlannedRun } from "@/lib/planned-run";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 const WEEKDAYS = [
   "Sunday",
@@ -108,7 +108,7 @@ function formatNextAssignmentDateParts(date: Date): NextAssignmentDateParts {
 
 function CompletedRunContent() {
   const router = useRouter();
-  const supabase = useMemo(() => createClientComponentClient(), []);
+  const supabase = useSupabase();
   const [runData, setRunData] = useState<RunSessionRecord | null | undefined>(
     undefined
   );

--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { useMapSettings, MapSettingsProvider } from "@/components/Context/MapSettingsContext";
 import { GoogleMap, Marker, Polyline, useLoadScript, Autocomplete } from "@react-google-maps/api";
 import polyline from "@mapbox/polyline";
@@ -18,6 +17,7 @@ import {
   markPlannedRunStarted,
 } from "@/lib/planned-run";
 import { readRunSession, writeRunSession } from "@/lib/run-session";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 const LIBRARIES: ("places")[] = ["places"];
 
@@ -56,7 +56,7 @@ export default function RunPage() {
 }
 
 function RunPageContent() {
-  const supabase = createClientComponentClient();
+  const supabase = useSupabase();
   const router = useRouter();
   const { mapStylePref } = useMapSettings();
   const mapRef = useRef<google.maps.Map | null>(null);

--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -6,9 +6,9 @@ import { useRouter } from "next/navigation";
 import { Flag, LogOut, Navigation2, Palette } from "lucide-react";
 import clsx from "clsx";
 import { useMapSettings } from "@/components/Context/MapSettingsContext";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { clearPlannedRun, readPlannedRun } from "@/lib/planned-run";
 import { readRunSession, writeRunSession } from "@/lib/run-session";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 type NavOptionKey = "google" | "waze" | "apple";
 type MapStyleKey = "Dark" | "Light" | "Satellite";
@@ -31,7 +31,7 @@ const mapStyleOptions: PickerOption<MapStyleKey>[] = [
 ];
 
 export default function SettingsDrawer() {
-  const supabase = createClientComponentClient();
+  const supabase = useSupabase();
   const router = useRouter();
   const { mapStylePref, setMapStylePref, navPref, setNavPref } = useMapSettings();
 
@@ -103,7 +103,9 @@ export default function SettingsDrawer() {
   // Load user preferences from Supabase on mount, create row if it doesn't exist
   useEffect(() => {
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) return;
 
       const { data: profile, error } = await supabase
@@ -126,7 +128,7 @@ export default function SettingsDrawer() {
         if (profile.nav_pref) setNavPref(profile.nav_pref);
       }
     })();
-  }, []);
+  }, [setMapStylePref, setNavPref, supabase]);
 
   useEffect(() => {
     syncActiveRunState();

--- a/components/UI/SmartJobCard.tsx
+++ b/components/UI/SmartJobCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import type { Job } from "@/lib/jobs";
+import { useSupabase } from "@/components/providers/SupabaseProvider";
 
 export default function SmartJobCard({
   job,
@@ -10,7 +10,7 @@ export default function SmartJobCard({
   job: Job;
   onCompleted: () => void;
 }) {
-  const supabase = createClientComponentClient();
+  const supabase = useSupabase();
 
   const [preview, setPreview] = useState<string | null>(null);
   const [file, setFile] = useState<File | null>(null);


### PR DESCRIPTION
## Summary
- replace direct Supabase client construction in staff UI and auth flows with the provider hook
- rely on the shared Supabase client for route, run, and proof components
- update settings-related components to use the provider-managed client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2cdf100f483328c0fe47098fcd2a0