### PR TITLE
Add POST handler for Supabase auth callbacks

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import type { Session } from '@supabase/supabase-js'
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
@@ -14,4 +15,34 @@ export async function GET(req: Request) {
   }
 
   return NextResponse.redirect(new URL(next, url.origin))
+}
+
+type SupabaseAuthWebhookPayload = {
+  event?: string
+  session?: Session | null
+}
+
+export async function POST(req: Request) {
+  let payload: SupabaseAuthWebhookPayload
+
+  try {
+    payload = (await req.json()) as SupabaseAuthWebhookPayload
+  } catch (error) {
+    return NextResponse.json({ received: false, error: 'Invalid JSON payload' }, { status: 400 })
+  }
+
+  const { event, session } = payload
+  const supabase = createRouteHandlerClient({ cookies })
+
+  if (event === 'SIGNED_OUT') {
+    await supabase.auth.signOut()
+  } else if (session) {
+    await supabase.auth.setSession(session)
+  }
+
+  const response = NextResponse.json({ received: true })
+  response.headers.set('Cache-Control', 'no-store')
+  response.headers.set('Access-Control-Allow-Origin', req.headers.get('origin') ?? '*')
+
+  return response
 }


### PR DESCRIPTION
## Summary
- add a Supabase auth webhook POST handler that reads the event payload
- update sessions by calling setSession or signOut and return a JSON acknowledgement

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2cf25bb58833296d83e41b374db6d