### PR TITLE
Adjust auth callback CORS handling

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -42,7 +42,33 @@ export async function POST(req: Request) {
 
   const response = NextResponse.json({ received: true })
   response.headers.set('Cache-Control', 'no-store')
-  response.headers.set('Access-Control-Allow-Origin', req.headers.get('origin') ?? '*')
+
+  const origin = req.headers.get('origin')
+  if (origin) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+    response.headers.set('Access-Control-Allow-Credentials', 'true')
+  }
+
+  return response
+}
+
+export async function OPTIONS(req: Request) {
+  const response = new Response(null, { status: 204 })
+
+  const origin = req.headers.get('origin')
+  if (origin) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+    response.headers.set('Access-Control-Allow-Credentials', 'true')
+  }
+
+  response.headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+
+  const requestedHeaders = req.headers.get('access-control-request-headers')
+  if (requestedHeaders) {
+    response.headers.set('Access-Control-Allow-Headers', requestedHeaders)
+  }
+
+  response.headers.set('Cache-Control', 'no-store')
 
   return response
 }


### PR DESCRIPTION
## Summary
- ensure the auth callback echoes the request origin and advertises credential support when present
- skip CORS headers for same-origin posts and respond to preflight requests with matching headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d64a2b048332b1e56a2900602de8