### PR TITLE
Refactor Supabase usage to provider hook

### DIFF
--- a/app/client/(auth)/login/page.tsx
+++ b/app/client/(auth)/login/page.tsx
@@ -3,10 +3,11 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { supabase } from '@/lib/supabaseClient'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export default function ClientLoginPage() {
+  const supabase = useSupabase()
   const router = useRouter()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')

--- a/app/client/(auth)/reset/page.tsx
+++ b/app/client/(auth)/reset/page.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { supabase } from '@/lib/supabaseClient'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export default function ClientResetPasswordPage() {
+  const supabase = useSupabase()
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState<'idle' | 'loading' | 'sent'>('idle')
   const [error, setError] = useState<string | null>(null)

--- a/app/ops/dashboard/page.tsx
+++ b/app/ops/dashboard/page.tsx
@@ -2,10 +2,11 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabaseClient'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 import BackButton from '@/components/UI/BackButton'
 
 export default function OpsDashboard() {
+  const supabase = useSupabase()
   const [stats, setStats] = useState({ clients: 0, logs: 0 })
   const [loading, setLoading] = useState(true)
 
@@ -22,7 +23,7 @@ export default function OpsDashboard() {
       setLoading(false)
     }
     load()
-  }, [])
+  }, [supabase])
 
   if (loading) return <div className="container">Loading…</div>
 

--- a/app/ops/logs/page.tsx
+++ b/app/ops/logs/page.tsx
@@ -1,8 +1,9 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabaseClient'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export default function LogsPage() {
+  const supabase = useSupabase()
   const [logs, setLogs] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
   const [signedUrls, setSignedUrls] = useState<Record<string, string>>({})
@@ -17,7 +18,7 @@ export default function LogsPage() {
       setLoading(false)
     }
     load()
-  }, [])
+  }, [supabase])
 
   useEffect(() => {
     if (logs.length === 0) return
@@ -61,7 +62,7 @@ export default function LogsPage() {
     return () => {
       cancelled = true
     }
-  }, [logs, signedUrls])
+  }, [logs, signedUrls, supabase])
 
   if (loading) return <div className="container">Loading…</div>
 

--- a/components/Dashboard/AdminDashboard.tsx
+++ b/components/Dashboard/AdminDashboard.tsx
@@ -2,9 +2,10 @@
 import Header from '../UI/Header'
 import Card from '../UI/Card'
 import { Users, Cog, FileText, KeyRound, LogOut } from 'lucide-react'
-import { supabase } from '@/lib/supabaseClient'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export default function AdminDashboard() {
+  const supabase = useSupabase()
   async function signOut() {
     await supabase.auth.signOut()
     window.location.href = '/'

--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabaseClient'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 import GuestDashboard from './GuestDashboard'
 import StaffDashboard from './StaffDashboard'
 import AdminDashboard from './AdminDashboard'
 
 export default function Dashboard() {
+  const supabase = useSupabase()
   const [loading, setLoading] = useState(true)
   const [role, setRole] = useState<string | null>(null)
 
@@ -29,7 +30,7 @@ export default function Dashboard() {
       setLoading(false)
     }
     load()
-  }, [])
+  }, [supabase])
 
   if (loading) {
     return (

--- a/components/Dashboard/StaffDashboard.tsx
+++ b/components/Dashboard/StaffDashboard.tsx
@@ -2,9 +2,10 @@
 import Header from '../UI/Header'
 import Card from '../UI/Card'
 import { Users, Cog, FileText, KeyRound, LogOut } from 'lucide-react'
-import { supabase } from '@/lib/supabaseClient'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export default function AdminDashboard() {
+  const supabase = useSupabase()
   async function signOut() {
     await supabase.auth.signOut()
     window.location.href = '/'

--- a/components/client/LiveTracker.tsx
+++ b/components/client/LiveTracker.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx'
 import { useClientPortal, type Job } from './ClientPortalProvider'
 import { TrackerMap } from './TrackerMap'
 import { useRealtimeJobs } from '@/hooks/useRealtimeJobs'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 const PROGRESS_STEPS: { key: Exclude<Job['status'], 'skipped'>; label: string }[] = [
   { key: 'scheduled', label: 'Scheduled' },
@@ -47,6 +48,7 @@ const formatJobDetail = (job: Job): string => {
 }
 
 export function LiveTracker() {
+  const supabase = useSupabase()
   const {
     jobs,
     properties,
@@ -79,7 +81,7 @@ export function LiveTracker() {
     [properties],
   )
 
-  useRealtimeJobs(selectedAccount?.id ?? null, realtimePropertyIds, (job) => {
+  useRealtimeJobs(supabase, selectedAccount?.id ?? null, realtimePropertyIds, (job) => {
     upsertJob(job)
   })
 

--- a/components/client/NotificationPreferencesForm.tsx
+++ b/components/client/NotificationPreferencesForm.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react'
 import { Switch } from '@headlessui/react'
 import { BellIcon, InboxIcon, PhoneIcon } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
-import { supabase } from '@/lib/supabaseClient'
 import { useClientPortal } from './ClientPortalProvider'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 const PREFERENCE_FIELDS = [
   {
@@ -41,6 +41,7 @@ type MutablePreferences = {
 
 export function NotificationPreferencesForm() {
   const { notificationPreferences, preferencesLoading, refreshNotificationPreferences, selectedAccount, user } = useClientPortal()
+  const supabase = useSupabase()
   const [formState, setFormState] = useState<MutablePreferences | null>(null)
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState<string | null>(null)

--- a/components/client/PortalHeader.tsx
+++ b/components/client/PortalHeader.tsx
@@ -2,11 +2,12 @@
 
 import { useMemo } from 'react'
 import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline'
-import { supabase } from '@/lib/supabaseClient'
 import { useClientPortal } from './ClientPortalProvider'
 import { AccountSwitcher } from './AccountSwitcher'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export function PortalHeader() {
+  const supabase = useSupabase()
   const { profile, user } = useClientPortal()
   const greeting = useMemo(() => {
     const hour = new Date().getHours()

--- a/components/client/ProofGalleryModal.tsx
+++ b/components/client/ProofGalleryModal.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment } from 'react'
 import { ArrowLeftIcon, ArrowRightIcon, XMarkIcon } from '@heroicons/react/24/outline'
-import { supabase } from '@/lib/supabaseClient'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export type ProofGalleryModalProps = {
   isOpen: boolean
@@ -13,6 +13,7 @@ export type ProofGalleryModalProps = {
 }
 
 export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryModalProps) {
+  const supabase = useSupabase()
   const [urls, setUrls] = useState<string[]>([])
   const [index, setIndex] = useState(0)
   const [loading, setLoading] = useState(false)
@@ -46,7 +47,7 @@ export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryMo
     return () => {
       cancelled = true
     }
-  }, [isOpen, photoKeys])
+  }, [isOpen, photoKeys, supabase])
 
   useEffect(() => {
     if (index >= urls.length) {

--- a/components/client/SettingsForm.tsx
+++ b/components/client/SettingsForm.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { supabase } from '@/lib/supabaseClient'
 import { useClientPortal } from './ClientPortalProvider'
+import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export type SettingsFormValues = {
   fullName: string
@@ -17,6 +17,7 @@ const TIMEZONES = Intl.supportedValuesOf ? Intl.supportedValuesOf('timeZone') : 
 
 export function SettingsForm() {
   const { profile, user, selectedAccount, refreshProperties } = useClientPortal()
+  const supabase = useSupabase()
   const [submitError, setSubmitError] = useState<string | null>(null)
   const {
     register,

--- a/hooks/useRealtimeJobs.ts
+++ b/hooks/useRealtimeJobs.ts
@@ -1,12 +1,11 @@
-'use client'
+"use client"
 
-import { useEffect } from 'react'
-import type { RealtimeChannel } from '@supabase/supabase-js'
-import { supabase } from '@/lib/supabaseClient'
-import type { Job } from '@/components/client/ClientPortalProvider'
-import { normaliseBinList } from '@/lib/binLabels'
-import { nextDay, setHours, setMinutes, startOfToday } from 'date-fns'
-import type { Day } from 'date-fns'
+import { useEffect } from "react"
+import type { RealtimeChannel, SupabaseClient } from "@supabase/supabase-js"
+import type { Job } from "@/components/client/ClientPortalProvider"
+import { normaliseBinList } from "@/lib/binLabels"
+import { nextDay, setHours, setMinutes, startOfToday } from "date-fns"
+import type { Day } from "date-fns"
 
 const WEEKDAY_LOOKUP: Record<string, Day> = {
   sunday: 0,
@@ -76,6 +75,7 @@ const createJobFromPayload = (payload: any, fallbackAccountId: string | null): J
 }
 
 export function useRealtimeJobs(
+  supabase: SupabaseClient,
   accountId: string | null,
   propertyIds: string[],
   onChange: (job: Job) => void,
@@ -131,5 +131,5 @@ export function useRealtimeJobs(
         supabase.removeChannel(channel)
       })
     }
-  }, [accountId, onChange, propertyIds])
+  }, [accountId, onChange, propertyIds, supabase])
 }

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,7 +1,0 @@
-import { createClient } from '@supabase/supabase-js'
-
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
-


### PR DESCRIPTION
## Summary
- replace Supabase singleton imports with the provider hook across client, dashboard, and auth components
- update the client portal provider to consume the shared Supabase instance and keep dependent effects in sync
- refactor the realtime jobs hook to accept an injected Supabase client and update LiveTracker accordingly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2d6c8b3f883329ff81491e5605da2