### PR TITLE
Hide scheduled jobs and fix proof modal close

### DIFF
--- a/__tests__/JobHistoryTable.test.tsx
+++ b/__tests__/JobHistoryTable.test.tsx
@@ -8,6 +8,16 @@ vi.mock('@/components/client/ClientPortalProvider', () => ({
   useClientPortal: () => ({ selectedAccount: { name: 'Test account' } }),
 }))
 
+vi.mock('@/components/providers/SupabaseProvider', () => ({
+  useSupabase: () => ({
+    storage: {
+      from: () => ({
+        createSignedUrls: async () => ({ data: [], error: null }),
+      }),
+    },
+  }),
+}))
+
 const jobs: Job[] = [
   {
     id: '1',
@@ -56,6 +66,13 @@ describe('JobHistoryTable', () => {
     render(<JobHistoryTable jobs={jobs} properties={properties} />)
     const table = screen.getByRole('table')
     expect(within(table).getByText('Alpha')).toBeInTheDocument()
-    expect(within(table).getByText(/Test account/)).toBeInTheDocument()
+    expect(screen.getByText(/Test account/)).toBeInTheDocument()
+  })
+
+  it('hides jobs that are not completed', () => {
+    const scheduledJob: Job = { ...jobs[0], id: '2', propertyName: 'Bravo', status: 'scheduled', completedAt: null }
+    render(<JobHistoryTable jobs={[...jobs, scheduledJob]} properties={properties} />)
+    const table = screen.getByRole('table')
+    expect(within(table).queryByText('Bravo')).not.toBeInTheDocument()
   })
 })

--- a/components/client/ProofGalleryModal.tsx
+++ b/components/client/ProofGalleryModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment } from 'react'
 import { ArrowLeftIcon, ArrowRightIcon, XMarkIcon } from '@heroicons/react/24/outline'
@@ -58,9 +58,16 @@ export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryMo
   const goPrevious = () => setIndex((current) => (current === 0 ? urls.length - 1 : current - 1))
   const goNext = () => setIndex((current) => (current + 1) % urls.length)
 
+  const handleClose = useCallback(() => {
+    setUrls([])
+    setIndex(0)
+    setLoading(false)
+    onClose()
+  }, [onClose])
+
   return (
     <Transition show={isOpen} as={Fragment}>
-      <Dialog onClose={onClose} className="relative z-50">
+      <Dialog onClose={handleClose} className="relative z-50">
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-200"
@@ -85,7 +92,8 @@ export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryMo
             >
               <Dialog.Panel className="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-white/10 bg-black/90 text-white shadow-2xl">
                 <button
-                  onClick={onClose}
+                  type="button"
+                  onClick={handleClose}
                   className="absolute right-4 top-4 rounded-full border border-white/20 bg-black/60 p-2 text-white/70 transition hover:border-binbird-red hover:text-white"
                   aria-label="Close proof of service"
                 >


### PR DESCRIPTION
## Summary
- filter client job history to only include completed or skipped jobs by default
- refresh property/status filters to use the completed job subset for exports and table rendering
- reset the proof gallery modal state on close and cover the behaviour with updated unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e30df560c883329cc00b72febc4c9b