### PR TITLE
Use logs for client history and fix proof gallery close

### DIFF
--- a/app/client/(portal)/history/page.tsx
+++ b/app/client/(portal)/history/page.tsx
@@ -4,7 +4,7 @@ import { useClientPortal } from '@/components/client/ClientPortalProvider'
 import { JobHistoryTable } from '@/components/client/JobHistoryTable'
 
 export default function ClientHistoryPage() {
-  const { jobs, properties, jobsLoading } = useClientPortal()
+  const { jobHistory, properties, jobsLoading } = useClientPortal()
 
   return (
     <section className="space-y-6">
@@ -21,7 +21,7 @@ export default function ClientHistoryPage() {
           </span>
         </div>
       ) : (
-        <JobHistoryTable jobs={jobs} properties={properties} />
+        <JobHistoryTable jobs={jobHistory} properties={properties} />
       )}
     </section>
   )

--- a/components/client/ProofGalleryModal.tsx
+++ b/components/client/ProofGalleryModal.tsx
@@ -85,8 +85,9 @@ export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryMo
             >
               <Dialog.Panel className="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-white/10 bg-black/90 text-white shadow-2xl">
                 <button
+                  type="button"
                   onClick={onClose}
-                  className="absolute right-4 top-4 rounded-full border border-white/20 bg-black/60 p-2 text-white/70 transition hover:border-binbird-red hover:text-white"
+                  className="absolute right-4 top-4 z-10 rounded-full border border-white/20 bg-black/60 p-2 text-white/70 transition hover:border-binbird-red hover:text-white"
                   aria-label="Close proof of service"
                 >
                   <XMarkIcon className="h-6 w-6" />


### PR DESCRIPTION
## Summary
- add a dedicated jobHistory feed built from recent log records in the client portal provider
- update the client history page to render only completed log entries from the new jobHistory data
- ensure the proof gallery modal close button works reliably when viewing proof photos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e310ae314483328b236a0eceb2e349