### PR TITLE
Revamp client job history layout and filters

### DIFF
--- a/app/client/(portal)/history/page.tsx
+++ b/app/client/(portal)/history/page.tsx
@@ -11,7 +11,7 @@ export default function ClientHistoryPage() {
       <div className="space-y-2">
         <h2 className="text-2xl font-semibold text-white">Job history</h2>
         <p className="text-sm text-white/60">
-          View the last 60 days of service events, export detailed reports, and access proof-of-service photos.
+          View the last 60 days of service events and access proof-of-service photos.
         </p>
       </div>
       {jobsLoading ? (

--- a/components/client/ProofGalleryModal.tsx
+++ b/components/client/ProofGalleryModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment } from 'react'
-import { ArrowLeftIcon, ArrowRightIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline'
 import { useSupabase } from '@/components/providers/SupabaseProvider'
 
 export type ProofGalleryModalProps = {
@@ -70,7 +70,7 @@ export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryMo
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black/70 backdrop-blur" />
+          <Dialog.Overlay className="fixed inset-0 bg-black/70 backdrop-blur" />
         </Transition.Child>
         <div className="fixed inset-0 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-6">
@@ -84,14 +84,6 @@ export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryMo
               leaveTo="opacity-0 scale-90"
             >
               <Dialog.Panel className="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-white/10 bg-black/90 text-white shadow-2xl">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="absolute right-4 top-4 z-10 rounded-full border border-white/20 bg-black/60 p-2 text-white/70 transition hover:border-binbird-red hover:text-white"
-                  aria-label="Close proof of service"
-                >
-                  <XMarkIcon className="h-6 w-6" />
-                </button>
                 <div className="aspect-video w-full bg-black/60">
                   {loading ? (
                     <div className="flex h-full items-center justify-center text-white/70">


### PR DESCRIPTION
## Summary
- replace the job history filters with property and search options that understand property addresses, update the CSV export, and reorder the table columns to show address, job details, proof photos, completion time, and notes
- surface a horizontal swipe hint for mobile, tweak the client history intro copy, and add autocomplete suggestions to the search field
- simplify the proof gallery modal by removing the close button and allowing the overlay to dismiss the modal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e32fc827d88332bd9848fba18fab9b