### PR TITLE
Improve client portal mobile responsiveness

### DIFF
--- a/app/client/(portal)/layout.tsx
+++ b/app/client/(portal)/layout.tsx
@@ -32,13 +32,13 @@ function PortalScaffold({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div className="relative min-h-screen bg-black px-4 py-10 text-white">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+    <div className="relative min-h-screen bg-black px-4 pb-24 pt-8 text-white sm:px-6 sm:pb-12 sm:pt-12 lg:px-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 sm:gap-8">
         <PortalHeader />
         <PortalNavigation />
       </div>
-      <div className="mx-auto mt-8 w-full max-w-6xl">
-        <div className="rounded-3xl border border-white/10 bg-black/80 p-6 text-white shadow-2xl shadow-black/25 backdrop-blur">
+      <div className="mx-auto mt-6 w-full max-w-6xl sm:mt-8">
+        <div className="rounded-3xl border border-white/10 bg-black/80 p-4 text-white shadow-2xl shadow-black/25 backdrop-blur sm:p-6">
           {children}
         </div>
       </div>

--- a/components/client/AccountSwitcher.tsx
+++ b/components/client/AccountSwitcher.tsx
@@ -11,7 +11,7 @@ export function AccountSwitcher() {
 
   if (accounts.length <= 1 || !selectedAccount) {
     return (
-      <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70">
+      <div className="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70">
         <UserCircleIcon className="h-5 w-5" />
         <div>
           <p className="font-medium text-white">{selectedAccount?.name ?? 'Primary Account'}</p>
@@ -24,7 +24,7 @@ export function AccountSwitcher() {
   return (
     <Listbox value={selectedAccount?.id} onChange={selectAccount}>
       {({ open }) => (
-        <div className="relative w-full max-w-xs">
+        <div className="relative w-full sm:max-w-xs">
           <Listbox.Button className="relative flex w-full items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-left text-sm font-medium text-white shadow-lg shadow-black/20 transition hover:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30">
             <span className="flex flex-col">
               <span>{selectedAccount?.name}</span>

--- a/components/client/JobHistoryTable.tsx
+++ b/components/client/JobHistoryTable.tsx
@@ -156,16 +156,16 @@ export function JobHistoryTable({ jobs, properties }: JobHistoryTableProps) {
             value={filters.propertyId}
             onChange={(value) => setFilters((current) => ({ ...current, propertyId: value }))}
             options={propertyOptions}
-            className="min-w-[200px]"
+            className="w-full md:min-w-[200px]"
           />
-          <label className="flex flex-col gap-1 text-sm">
+          <label className="flex w-full flex-col gap-1 text-sm">
             <span className="text-white/60">Search</span>
             <input
               type="search"
               value={filters.search}
               onChange={(event) => setFilters((current) => ({ ...current, search: event.target.value }))}
               placeholder="Search by property, address, or notes"
-              className="min-w-[220px] rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30 md:min-w-[220px]"
               list={searchListId}
             />
           </label>
@@ -175,11 +175,11 @@ export function JobHistoryTable({ jobs, properties }: JobHistoryTableProps) {
             ))}
           </datalist>
         </div>
-        <div className="flex flex-wrap gap-3">
+        <div className="flex flex-col gap-3 md:flex-row md:flex-wrap">
           <button
             type="button"
             onClick={handleDownloadCsv}
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red md:w-auto"
           >
             <DocumentArrowDownIcon className="h-5 w-5" /> Export CSV
           </button>

--- a/components/client/PortalHeader.tsx
+++ b/components/client/PortalHeader.tsx
@@ -21,7 +21,7 @@ export function PortalHeader() {
   }
 
   return (
-    <header className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/70 p-6 text-white shadow-2xl shadow-black/30 backdrop-blur-lg sm:flex-row sm:items-center sm:justify-between">
+    <header className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/70 p-4 text-white shadow-2xl shadow-black/30 backdrop-blur-lg sm:flex-row sm:items-center sm:justify-between sm:p-6">
       <div>
         <p className="text-sm uppercase tracking-[0.45em] text-white/40">{greeting}</p>
         <h1 className="mt-2 text-2xl font-semibold text-white">
@@ -34,7 +34,7 @@ export function PortalHeader() {
         <button
           type="button"
           onClick={handleSignOut}
-          className="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:bg-binbird-red/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:bg-binbird-red/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:w-auto"
         >
           <ArrowRightOnRectangleIcon className="h-5 w-5" />
           Sign out

--- a/components/client/PortalNavigation.tsx
+++ b/components/client/PortalNavigation.tsx
@@ -25,7 +25,7 @@ export function PortalNavigation() {
   const pathname = usePathname()
 
   return (
-    <nav className="flex w-full flex-wrap items-center gap-2 rounded-3xl border border-white/10 bg-black/60 p-2 text-sm text-white shadow-2xl shadow-black/20 backdrop-blur">
+    <nav className="flex w-full flex-nowrap items-center gap-2 overflow-x-auto rounded-3xl border border-white/10 bg-black/60 p-2 text-sm text-white shadow-2xl shadow-black/20 backdrop-blur [-webkit-overflow-scrolling:touch] sm:flex-wrap sm:overflow-visible sm:snap-none snap-x snap-mandatory">
       {NAV_ITEMS.map((item) => {
         const active = pathname.startsWith(item.href)
         return (
@@ -33,7 +33,7 @@ export function PortalNavigation() {
             key={item.href}
             href={item.href}
             className={clsx(
-              'flex flex-1 items-center justify-center gap-2 rounded-2xl px-3 py-2 font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:flex-none sm:px-4',
+              'flex min-w-[140px] flex-none snap-start items-center justify-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-w-0 sm:flex-1 sm:px-4',
               active ? 'bg-binbird-red text-white shadow-lg shadow-red-900/40' : 'text-white/60 hover:text-white hover:bg-white/5',
             )}
             aria-current={active ? 'page' : undefined}

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -59,19 +59,19 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
             placeholder="Search by name or suburb"
             value={filters.search}
             onChange={(event) => update({ search: event.target.value })}
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
           />
         </label>
         <label className="flex flex-col gap-2 text-sm">
           <span className="text-white/60">Status</span>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             {(Object.keys(STATUS_LABELS) as PropertyFilterState['status'][]).map((status) => (
               <button
                 key={status}
                 type="button"
                 onClick={() => update({ status })}
                 className={clsx(
-                  'flex-1 rounded-2xl border px-4 py-2 text-sm font-medium transition',
+                  'flex-1 rounded-2xl border px-4 py-2 text-sm font-medium transition sm:flex-none sm:px-6 min-w-[120px]',
                   filters.status === status
                     ? 'border-binbird-red bg-binbird-red/20 text-white'
                     : 'border-white/10 bg-black/40 text-white/60 hover:border-binbird-red/40 hover:text-white',


### PR DESCRIPTION
## Summary
- adjust the client portal scaffold, header, and card padding to better fit on small screens
- make the navigation bar horizontally scrollable and widen account controls for phone viewports
- update property and job history filters to avoid overflow and keep actions usable on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e33f0fcf5c8332a79defa7fe3d42d8