### PR TITLE
Revamp client dashboard property cards

### DIFF
--- a/__tests__/JobHistoryTable.test.tsx
+++ b/__tests__/JobHistoryTable.test.tsx
@@ -39,6 +39,8 @@ const properties: Property[] = [
     city: 'Melbourne',
     status: 'active',
     binTypes: ['General'],
+    binCounts: { garbage: 1, recycling: 0, compost: 0, total: 1 },
+    binDescriptions: { garbage: 'Garbage (weekly)', recycling: null, compost: null },
     nextServiceAt: null,
     latitude: null,
     longitude: null,

--- a/app/client/(portal)/history/page.tsx
+++ b/app/client/(portal)/history/page.tsx
@@ -1,10 +1,13 @@
 'use client'
 
+import { useSearchParams } from 'next/navigation'
 import { useClientPortal } from '@/components/client/ClientPortalProvider'
 import { JobHistoryTable } from '@/components/client/JobHistoryTable'
 
 export default function ClientHistoryPage() {
   const { jobHistory, properties, jobsLoading } = useClientPortal()
+  const searchParams = useSearchParams()
+  const initialPropertyId = searchParams.get('propertyId')
 
   return (
     <section className="space-y-6">
@@ -21,7 +24,7 @@ export default function ClientHistoryPage() {
           </span>
         </div>
       ) : (
-        <JobHistoryTable jobs={jobHistory} properties={properties} />
+        <JobHistoryTable jobs={jobHistory} properties={properties} initialPropertyId={initialPropertyId} />
       )}
     </section>
   )

--- a/components/client/JobHistoryTable.tsx
+++ b/components/client/JobHistoryTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Fragment, useId, useMemo, useState } from 'react'
+import { Fragment, useEffect, useId, useMemo, useState } from 'react'
 import { format } from 'date-fns'
 import { CheckIcon, ChevronUpDownIcon, DocumentArrowDownIcon, PhotoIcon } from '@heroicons/react/24/outline'
 import { saveAs } from 'file-saver'
@@ -12,6 +12,7 @@ import { ProofGalleryModal } from './ProofGalleryModal'
 export type JobHistoryTableProps = {
   jobs: Job[]
   properties: Property[]
+  initialPropertyId?: string | null
 }
 
 type HistoryFilters = {
@@ -50,11 +51,24 @@ const formatAddress = (property: Property | undefined) => {
 
 const escapeForCsv = (value: string) => `"${value.replace(/"/g, '""')}"`
 
-export function JobHistoryTable({ jobs, properties }: JobHistoryTableProps) {
-  const [filters, setFilters] = useState<HistoryFilters>(DEFAULT_FILTERS)
+export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHistoryTableProps) {
+  const [filters, setFilters] = useState<HistoryFilters>(() => ({
+    ...DEFAULT_FILTERS,
+    propertyId: initialPropertyId && initialPropertyId.length > 0 ? initialPropertyId : DEFAULT_FILTERS.propertyId,
+  }))
   const [proofJob, setProofJob] = useState<Job | null>(null)
   const { selectedAccount } = useClientPortal()
   const searchListId = useId()
+
+  useEffect(() => {
+    setFilters((current) => {
+      const nextPropertyId = initialPropertyId && initialPropertyId.length > 0 ? initialPropertyId : 'all'
+      if (current.propertyId === nextPropertyId) {
+        return current
+      }
+      return { ...current, propertyId: nextPropertyId }
+    })
+  }, [initialPropertyId])
 
   const propertyMap = useMemo(() => {
     const map = new Map<string, Property>()

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -1,21 +1,23 @@
+
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { format } from 'date-fns'
-import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { useRouter } from 'next/navigation'
 import type { Property } from './ClientPortalProvider'
 import { PropertyFilters, type PropertyFilterState } from './PropertyFilters'
 
 const DEFAULT_FILTERS: PropertyFilterState = {
   search: '',
-  status: 'all',
 }
 
 function matchesFilters(property: Property, filters: PropertyFilterState) {
-  if (filters.status !== 'all' && property.status !== filters.status) return false
   if (filters.search) {
     const term = filters.search.toLowerCase()
-    if (!property.name.toLowerCase().includes(term) && !property.suburb.toLowerCase().includes(term)) {
+    const candidates = [property.name, property.addressLine, property.suburb, property.city]
+      .filter((value): value is string => Boolean(value))
+      .map((value) => value.toLowerCase())
+    if (!candidates.some((value) => value.includes(term))) {
       return false
     }
   }
@@ -30,16 +32,48 @@ function groupProperties(properties: Property[]) {
   }, {})
 }
 
+const BIN_BADGE_STYLES: Record<'garbage' | 'recycling' | 'compost', string> = {
+  garbage: 'bg-red-600 text-white',
+  recycling: 'bg-yellow-500 text-black',
+  compost: 'bg-green-600 text-white',
+}
+
+const formatBinFrequency = (description: string | null) => {
+  if (!description) return 'Schedule not set'
+  const frequencyMatch = description.match(/\(([^)]+)\)/)
+  const frequency = frequencyMatch?.[1]
+  const extras: string[] = []
+  if (frequency) {
+    const cleaned = frequency.charAt(0).toUpperCase() + frequency.slice(1)
+    extras.push(cleaned)
+  }
+  if (/alternate weeks/i.test(description)) {
+    extras.push('Alternate weeks')
+  }
+  if (extras.length === 0) {
+    return 'Schedule not set'
+  }
+  return extras.join(', ')
+}
+
 export type PropertyDashboardProps = {
   properties: Property[]
   isLoading: boolean
 }
 
 export function PropertyDashboard({ properties, isLoading }: PropertyDashboardProps) {
+  const router = useRouter()
   const [filters, setFilters] = useState<PropertyFilterState>(DEFAULT_FILTERS)
 
   const filtered = useMemo(() => properties.filter((property) => matchesFilters(property, filters)), [properties, filters])
   const grouped = useMemo(() => groupProperties(filtered), [filtered])
+
+  const handlePropertyClick = useCallback(
+    (propertyId: string) => {
+      router.push(`/client/(portal)/history?propertyId=${encodeURIComponent(propertyId)}`)
+    },
+    [router],
+  )
 
   return (
     <div className="space-y-6 text-white">
@@ -61,72 +95,112 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
         </div>
       ) : (
         <div className="space-y-10">
-          {Object.entries(grouped).map(([groupName, groupProperties]) => (
-            <section key={groupName} className="space-y-4">
-              <header className="flex items-center justify-between text-sm text-white/60">
-                <div>
-                  <h3 className="text-lg font-semibold text-white">{groupName}</h3>
-                  <p>{groupProperties.length} properties</p>
-                </div>
-              </header>
-              <div className="grid gap-4 md:grid-cols-2">
-                {groupProperties.map((property) => (
-                  <article
-                    key={property.id}
-                    className="group flex flex-col rounded-3xl border border-white/10 bg-white/5 p-5 transition hover:border-binbird-red hover:bg-binbird-red/10"
-                  >
-                    <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <h4 className="text-xl font-semibold text-white">
-                          {property.addressLine}, {property.suburb}
-                        </h4>
-                      </div>
-                      <span
-                        className="rounded-full border border-white/20 px-3 py-1 text-xs uppercase tracking-wide text-white/70"
-                        aria-label={`Status: ${property.status}`}
+          {Object.entries(grouped).map(([groupName, groupProperties]) => {
+            const propertyCount = groupProperties.length
+            const propertyCountLabel = `${propertyCount} ${propertyCount === 1 ? 'property' : 'properties'}`
+            return (
+              <section key={groupName} className="space-y-4">
+                <header className="flex items-center justify-between text-sm text-white/60">
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">{groupName}</h3>
+                    <p>{propertyCountLabel}</p>
+                  </div>
+                </header>
+                <div className="grid auto-rows-fr gap-4 md:grid-cols-2">
+                  {groupProperties.map((property) => {
+                    const addressParts = [property.addressLine, property.suburb].filter((part) => part && part.trim().length > 0)
+                    const address = addressParts.join(', ')
+                    const binSummaries: Array<{
+                      key: 'garbage' | 'recycling' | 'compost'
+                      label: string
+                      count: number
+                      description: string
+                    }> = [
+                      {
+                        key: 'garbage',
+                        label: 'Garbage',
+                        count: property.binCounts.garbage,
+                        description: formatBinFrequency(property.binDescriptions.garbage),
+                      },
+                      {
+                        key: 'recycling',
+                        label: 'Recycling',
+                        count: property.binCounts.recycling,
+                        description: formatBinFrequency(property.binDescriptions.recycling),
+                      },
+                      {
+                        key: 'compost',
+                        label: 'Compost',
+                        count: property.binCounts.compost,
+                        description: formatBinFrequency(property.binDescriptions.compost),
+                      },
+                    ]
+
+                    return (
+                      <button
+                        key={property.id}
+                        type="button"
+                        onClick={() => handlePropertyClick(property.id)}
+                        className="group flex h-full min-h-[320px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-5 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red"
+                        aria-label={`View job history for ${property.name}`}
                       >
-                        {property.status === 'active' ? 'Active' : 'Paused'}
-                      </span>
-                    </div>
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      {property.binTypes.map((bin) => (
-                        <span
-                          key={bin}
-                          className="rounded-full bg-black/60 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white/70"
-                        >
-                          {bin}
-                        </span>
-                      ))}
-                    </div>
-                    <div className="mt-6 flex flex-wrap items-center justify-between gap-4 text-sm text-white/60">
-                      <p>
-                        Next service:
-                        <span className="ml-2 font-medium text-white">
-                          {property.nextServiceAt ? format(new Date(property.nextServiceAt), 'EEE, MMM d') : 'Awaiting schedule'}
-                        </span>
-                      </p>
-                      <p className="text-xs text-white/50">
-                        Put out: {property.putOutDay ?? '—'} · Collection: {property.collectionDay ?? '—'}
-                      </p>
-                      {property.latitude && property.longitude ? (
-                        <a
-                          className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white/70 transition hover:border-binbird-red hover:text-white"
-                          href={`https://www.google.com/maps/search/?api=1&query=${property.latitude},${property.longitude}`}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Open map
-                          <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-                        </a>
-                      ) : (
-                        <span className="text-xs text-white/40">Location pending</span>
-                      )}
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </section>
-          ))}
+                        <div className="flex flex-1 flex-col gap-6">
+                          <div className="space-y-3">
+                            <div className="space-y-2">
+                              <h4 className="text-xl font-semibold text-white">
+                                {address || property.name}
+                              </h4>
+                              {property.name && address && property.name !== address && (
+                                <p className="text-sm text-white/60">{property.name}</p>
+                              )}
+                            </div>
+                            <div className="space-y-1 text-xs uppercase tracking-wide text-white/50">
+                              <p>Property code</p>
+                              <p className="text-sm font-medium text-white normal-case">{property.id}</p>
+                            </div>
+                          </div>
+                          <div className="grid gap-3 sm:grid-cols-3">
+                            {binSummaries.map((bin) => (
+                              <div key={bin.key} className="flex items-center gap-3 rounded-2xl bg-black/40 p-3">
+                                <span
+                                  className={`flex h-10 w-10 items-center justify-center rounded-xl text-sm font-semibold ${BIN_BADGE_STYLES[bin.key]}`}
+                                >
+                                  {bin.count}
+                                </span>
+                                <div className="min-w-0">
+                                  <p className="text-sm font-medium text-white">{bin.label}</p>
+                                  <p className="text-xs text-white/60">{bin.description}</p>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                        <div className="mt-6 space-y-2 text-sm text-white/60">
+                          <p>
+                            Next service:
+                            <span className="ml-2 font-medium text-white">
+                              {property.nextServiceAt ? format(new Date(property.nextServiceAt), 'EEE, MMM d') : 'Awaiting schedule'}
+                            </span>
+                          </p>
+                          <p className="text-xs text-white/50">
+                            Put out: {property.putOutDay ?? '—'} · Collection: {property.collectionDay ?? '—'}
+                          </p>
+                        </div>
+                        <div className="mt-6 flex items-center justify-between text-xs font-medium uppercase tracking-wide text-white/60">
+                          <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-white">
+                            Total bins: {property.binCounts.total}
+                          </span>
+                          <span className="flex items-center gap-2 text-white/70 transition group-hover:text-white">
+                            View job history <span aria-hidden>→</span>
+                          </span>
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              </section>
+            )
+          })}
         </div>
       )}
     </div>

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -1,20 +1,11 @@
 'use client'
 
-import { useMemo } from 'react'
-import clsx from 'clsx'
+import { useId, useMemo } from 'react'
 import { FunnelIcon } from '@heroicons/react/24/outline'
 import type { Property } from './ClientPortalProvider'
-import { formatBinLabel } from '@/lib/binLabels'
 
 export type PropertyFilterState = {
   search: string
-  status: 'all' | 'active' | 'paused'
-}
-
-const STATUS_LABELS: Record<PropertyFilterState['status'], string> = {
-  all: 'All statuses',
-  active: 'Active',
-  paused: 'Paused',
 }
 
 export type PropertyFiltersProps = {
@@ -23,23 +14,43 @@ export type PropertyFiltersProps = {
   properties: Property[]
 }
 
+const formatAddress = (property: Property) => {
+  const parts = [property.addressLine, property.suburb, property.city]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+  return parts.join(', ')
+}
+
+const formatBinTotal = (value: number) => (value > 0 ? value : 0)
+
 export function PropertyFilters({ filters, onChange, properties }: PropertyFiltersProps) {
   const totals = useMemo(() => {
-    const totalBins = properties.reduce(
+    return properties.reduce(
       (accumulator, property) => {
-        property.binTypes.forEach((bin) => {
-          const label = formatBinLabel(bin)
-          if (label === 'Recycling') accumulator.recycling += 1
-          else if (label === 'Compost') accumulator.compost += 1
-          else if (label === 'Garbage') accumulator.garbage += 1
-        })
+        accumulator.garbage += property.binCounts?.garbage ?? 0
+        accumulator.recycling += property.binCounts?.recycling ?? 0
+        accumulator.compost += property.binCounts?.compost ?? 0
         return accumulator
       },
       { garbage: 0, recycling: 0, compost: 0 },
     )
-
-    return totalBins
   }, [properties])
+
+  const searchSuggestions = useMemo(() => {
+    const suggestions = new Set<string>()
+    properties.forEach((property) => {
+      if (property.name) {
+        suggestions.add(property.name)
+      }
+      const address = formatAddress(property)
+      if (address) {
+        suggestions.add(address)
+      }
+    })
+    return Array.from(suggestions).sort((a, b) => a.localeCompare(b))
+  }, [properties])
+
+  const searchListId = useId()
 
   const update = (partial: Partial<PropertyFilterState>) => {
     onChange({ ...filters, ...partial })
@@ -51,8 +62,8 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
         <FunnelIcon className="h-5 w-5" />
         <span>Filter properties</span>
       </div>
-      <div className="grid gap-4 md:grid-cols-2">
-        <label className="flex flex-col gap-2 text-sm">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <label className="flex w-full flex-col gap-2 text-sm md:max-w-sm">
           <span className="text-white/60">Search</span>
           <input
             type="search"
@@ -60,43 +71,29 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
             value={filters.search}
             onChange={(event) => update({ search: event.target.value })}
             className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            list={searchListId}
           />
-        </label>
-        <label className="flex flex-col gap-2 text-sm">
-          <span className="text-white/60">Status</span>
-          <div className="flex flex-wrap gap-2">
-            {(Object.keys(STATUS_LABELS) as PropertyFilterState['status'][]).map((status) => (
-              <button
-                key={status}
-                type="button"
-                onClick={() => update({ status })}
-                className={clsx(
-                  'flex-1 rounded-2xl border px-4 py-2 text-sm font-medium transition sm:flex-none sm:px-6 min-w-[120px]',
-                  filters.status === status
-                    ? 'border-binbird-red bg-binbird-red/20 text-white'
-                    : 'border-white/10 bg-black/40 text-white/60 hover:border-binbird-red/40 hover:text-white',
-                )}
-              >
-                {STATUS_LABELS[status]}
-              </button>
+          <datalist id={searchListId}>
+            {searchSuggestions.map((suggestion) => (
+              <option key={suggestion} value={suggestion} />
             ))}
-          </div>
+          </datalist>
         </label>
+        <dl className="grid flex-1 gap-3 sm:grid-cols-3 md:auto-cols-fr md:grid-flow-col">
+          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+            <dt className="text-xs uppercase tracking-wide text-white/50">Garbage bins</dt>
+            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.garbage)}</dd>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+            <dt className="text-xs uppercase tracking-wide text-white/50">Recycling bins</dt>
+            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.recycling)}</dd>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+            <dt className="text-xs uppercase tracking-wide text-white/50">Compost bins</dt>
+            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.compost)}</dd>
+          </div>
+        </dl>
       </div>
-      <dl className="mt-6 grid gap-4 sm:grid-cols-3">
-        <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-          <dt className="text-xs uppercase tracking-wide text-white/50">Garbage bins</dt>
-          <dd className="mt-1 text-2xl font-semibold">{totals.garbage}</dd>
-        </div>
-        <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-          <dt className="text-xs uppercase tracking-wide text-white/50">Recycling bins</dt>
-          <dd className="mt-1 text-2xl font-semibold">{totals.recycling}</dd>
-        </div>
-        <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-          <dt className="text-xs uppercase tracking-wide text-white/50">Compost bins</dt>
-          <dd className="mt-1 text-2xl font-semibold">{totals.compost}</dd>
-        </div>
-      </dl>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- pull the new per-bin counts from `client_list` and expose them on client portal properties
- redesign the client dashboard property cards and filters for consistent sizing, colour-coded bin totals, and navigation into job history
- let the job history table accept an initial property filter from the URL and update related tests

## Testing
- `npm run test -- JobHistoryTable` *(fails: vitest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e3442a082c8332bcf0d43b82f1702f