### PR TITLE
Adjust property dashboard bin cadence display

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -153,10 +153,10 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         key={property.id}
                         type="button"
                         onClick={() => handlePropertyClick(property.id)}
-                        className="group flex h-full min-h-[320px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[380px] sm:p-7 lg:min-h-[400px]"
+                        className="group flex h-full min-h-[280px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[320px] sm:p-6 lg:min-h-[360px]"
                         aria-label={`View job history for ${property.name}`}
                       >
-                        <div className="flex flex-1 flex-col gap-6">
+                        <div className="flex flex-1 flex-col gap-5">
                           <div className="space-y-3">
                             <div className="space-y-2">
                               <h4 className="text-xl font-semibold text-white">
@@ -171,12 +171,12 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                 <div
                                   key={bin.key}
                                   className={clsx(
-                                    'flex h-full min-h-[120px] flex-col justify-between rounded-2xl border px-5 py-6 transition-colors',
+                                    'flex h-full min-h-[112px] flex-col justify-between rounded-2xl border px-4 py-5 transition-colors',
                                     BIN_THEME[bin.key].panel,
                                   )}
                                 >
-                                  <div className="space-y-2">
-                                    <p className="text-base font-semibold text-white sm:text-lg">
+                                  <div className="space-y-1.5">
+                                    <p className="text-base font-semibold leading-tight text-white sm:text-lg">
                                       {bin.count} {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
                                     </p>
                                     <p className="text-sm text-white/70">

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -170,7 +170,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         key={property.id}
                         type="button"
                         onClick={() => handlePropertyClick(property.id)}
-                        className="group flex h-full min-h-[320px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-5 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red"
+                        className="group flex h-full min-h-[280px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-5 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[320px] sm:p-6"
                         aria-label={`View job history for ${property.name}`}
                       >
                         <div className="flex flex-1 flex-col gap-6">
@@ -183,7 +183,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                 <p className="text-sm text-white/60">{property.name}</p>
                               )}
                             </div>
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                               {binSummaries.map((bin) => (
                                 <div
                                   key={bin.key}
@@ -202,30 +202,34 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                       >
                                         {bin.count}
                                       </span>
-                                      <div className="space-y-1">
+                                      <div className="space-y-1.5">
                                         <p className="text-sm font-semibold text-white sm:text-base">
                                           {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
                                         </p>
-                                        <p className={clsx('text-[11px] font-semibold uppercase tracking-wide', BIN_THEME[bin.key].label)}>
-                                          Collection frequency
+                                        <p
+                                          className={clsx(
+                                            'inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-[11px] font-semibold tracking-wide',
+                                            BIN_THEME[bin.key].label,
+                                            bin.description === 'Schedule not set'
+                                              ? 'bg-white/5 text-white/60'
+                                              : 'bg-white/10',
+                                          )}
+                                        >
+                                          {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
                                         </p>
                                       </div>
                                     </div>
-                                    <div className="flex items-center gap-2 text-xs font-medium text-white/70">
-                                      <CalendarIcon
-                                        className={clsx('h-4 w-4 shrink-0', BIN_THEME[bin.key].icon)}
-                                        aria-hidden
-                                      />
-                                      <span
-                                        className={clsx(
-                                          bin.description === 'Schedule not set'
-                                            ? 'text-white/60'
-                                            : BIN_THEME[bin.key].frequencyText,
-                                        )}
-                                      >
-                                        {bin.description}
-                                      </span>
-                                    </div>
+                                    {bin.description !== 'Schedule not set' && (
+                                      <div className="flex items-center gap-2 text-xs font-medium text-white/70">
+                                        <CalendarIcon
+                                          className={clsx('h-4 w-4 shrink-0', BIN_THEME[bin.key].icon)}
+                                          aria-hidden
+                                        />
+                                        <span className={BIN_THEME[bin.key].frequencyText}>
+                                          {bin.description}
+                                        </span>
+                                      </div>
+                                    )}
                                   </div>
                                 </div>
                               ))}

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -153,7 +153,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         key={property.id}
                         type="button"
                         onClick={() => handlePropertyClick(property.id)}
-                        className="group flex h-full min-h-[280px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-5 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[320px] sm:p-6"
+                        className="group flex h-full min-h-[320px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[380px] sm:p-7 lg:min-h-[400px]"
                         aria-label={`View job history for ${property.name}`}
                       >
                         <div className="flex flex-1 flex-col gap-6">
@@ -171,7 +171,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                 <div
                                   key={bin.key}
                                   className={clsx(
-                                    'flex h-full flex-col justify-between rounded-2xl border px-4 py-5 transition-colors',
+                                    'flex h-full min-h-[120px] flex-col justify-between rounded-2xl border px-5 py-6 transition-colors',
                                     BIN_THEME[bin.key].panel,
                                   )}
                                 >

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -1,7 +1,6 @@
 
 'use client'
 
-import { CalendarIcon } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
 import { useCallback, useMemo, useState } from 'react'
 import { format } from 'date-fns'
@@ -38,32 +37,16 @@ const BIN_THEME: Record<
   'garbage' | 'recycling' | 'compost',
   {
     panel: string
-    badge: string
-    label: string
-    frequencyText: string
-    icon: string
   }
 > = {
   garbage: {
     panel: 'border-red-500/30 bg-red-500/5',
-    badge: 'bg-red-500 text-white shadow-[0_5px_15px_-8px_rgba(248,113,113,0.7)]',
-    label: 'text-red-200/80',
-    frequencyText: 'text-red-100/80',
-    icon: 'text-red-200/70',
   },
   recycling: {
     panel: 'border-yellow-400/40 bg-yellow-400/10',
-    badge: 'bg-yellow-400 text-black shadow-[0_5px_15px_-8px_rgba(234,179,8,0.6)]',
-    label: 'text-yellow-100/80',
-    frequencyText: 'text-yellow-900/70',
-    icon: 'text-yellow-100/70',
   },
   compost: {
     panel: 'border-green-500/30 bg-green-500/10',
-    badge: 'bg-green-500 text-white shadow-[0_5px_15px_-8px_rgba(34,197,94,0.6)]',
-    label: 'text-green-100/70',
-    frequencyText: 'text-green-100/80',
-    icon: 'text-green-100/70',
   },
 }
 
@@ -192,44 +175,13 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                     BIN_THEME[bin.key].panel,
                                   )}
                                 >
-                                  <div className="flex flex-col gap-4">
-                                    <div className="flex items-center gap-3">
-                                      <span
-                                        className={clsx(
-                                          'flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-base font-semibold',
-                                          BIN_THEME[bin.key].badge,
-                                        )}
-                                      >
-                                        {bin.count}
-                                      </span>
-                                      <div className="space-y-1.5">
-                                        <p className="text-sm font-semibold text-white sm:text-base">
-                                          {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
-                                        </p>
-                                        <p
-                                          className={clsx(
-                                            'inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-[11px] font-semibold tracking-wide',
-                                            BIN_THEME[bin.key].label,
-                                            bin.description === 'Schedule not set'
-                                              ? 'bg-white/5 text-white/60'
-                                              : 'bg-white/10',
-                                          )}
-                                        >
-                                          {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
-                                        </p>
-                                      </div>
-                                    </div>
-                                    {bin.description !== 'Schedule not set' && (
-                                      <div className="flex items-center gap-2 text-xs font-medium text-white/70">
-                                        <CalendarIcon
-                                          className={clsx('h-4 w-4 shrink-0', BIN_THEME[bin.key].icon)}
-                                          aria-hidden
-                                        />
-                                        <span className={BIN_THEME[bin.key].frequencyText}>
-                                          {bin.description}
-                                        </span>
-                                      </div>
-                                    )}
+                                  <div className="space-y-2">
+                                    <p className="text-base font-semibold text-white sm:text-lg">
+                                      {bin.count} {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
+                                    </p>
+                                    <p className="text-sm text-white/70">
+                                      {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
+                                    </p>
                                   </div>
                                 </div>
                               ))}


### PR DESCRIPTION
## Summary
- show the bin collection cadence directly in the badge instead of the "Collection frequency" label
- keep the calendar row only when a cadence exists and improve the badge styling
- tweak card spacing and grid defaults for a better mobile layout

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e35497818083328241be6dcdcff584