### PR TITLE
Fix client history navigation path

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -82,7 +82,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
 
   const handlePropertyClick = useCallback(
     (propertyId: string) => {
-      router.push(`/client/(portal)/history?propertyId=${encodeURIComponent(propertyId)}`)
+      router.push(`/client/history?propertyId=${encodeURIComponent(propertyId)}`)
     },
     [router],
   )


### PR DESCRIPTION
## Summary
- update the property dashboard card navigation to route to the existing /client/history page instead of a route-group path

## Testing
- npm test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3660d82d48332b205d24546c2ff57