### PR TITLE
Handle comma-separated property search terms

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -14,11 +14,21 @@ const DEFAULT_FILTERS: PropertyFilterState = {
 
 function matchesFilters(property: Property, filters: PropertyFilterState) {
   if (filters.search) {
-    const term = filters.search.toLowerCase()
+    const lowerSearch = filters.search.toLowerCase()
+    const terms = lowerSearch
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
     const candidates = [property.name, property.addressLine, property.suburb, property.city]
       .filter((value): value is string => Boolean(value))
       .map((value) => value.toLowerCase())
-    if (!candidates.some((value) => value.includes(term))) {
+
+    if (terms.length === 0) {
+      return true
+    }
+
+    const matchesAllTerms = terms.every((term) => candidates.some((value) => value.includes(term)))
+    if (!matchesAllTerms) {
       return false
     }
   }

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -15,9 +15,20 @@ export type PropertyFiltersProps = {
 }
 
 const formatAddress = (property: Property) => {
+  const seen = new Set<string>()
   const parts = [property.addressLine, property.suburb, property.city]
     .map((part) => part?.trim())
-    .filter((part): part is string => Boolean(part))
+    .filter((part): part is string => {
+      if (!part) {
+        return false
+      }
+      const lower = part.toLowerCase()
+      if (seen.has(lower)) {
+        return false
+      }
+      seen.add(lower)
+      return true
+    })
   return parts.join(', ')
 }
 
@@ -39,8 +50,10 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
   const searchSuggestions = useMemo(() => {
     const suggestions = new Set<string>()
     properties.forEach((property) => {
-      if (property.name) {
-        suggestions.add(property.name)
+      const addressLine = property.addressLine?.trim().toLowerCase()
+      const name = property.name?.trim()
+      if (name && name.toLowerCase() !== addressLine) {
+        suggestions.add(name)
       }
       const address = formatAddress(property)
       if (address) {


### PR DESCRIPTION
## Summary
- normalize property search filters to match each comma-separated part independently
- ensure suggestions like full address strings still match the underlying property records

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3690030b0833285902d965909d22f