### PR TITLE
Fix client portal address parsing

### DIFF
--- a/components/client/ClientPortalProvider.tsx
+++ b/components/client/ClientPortalProvider.tsx
@@ -301,9 +301,22 @@ const deriveAccountId = (row: ClientListRow): string =>
 const deriveAccountName = (row: ClientListRow): string =>
   row.company?.trim() || row.client_name?.trim() || 'My Properties'
 
+const parseAddress = (
+  address: string | null | undefined,
+): { addressLine: string; suburb: string; city: string } => {
+  const parts = (address ?? '')
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+
+  const [addressLine = '', suburb = '', ...rest] = parts
+  const city = rest.join(', ') || suburb
+
+  return { addressLine, suburb, city }
+}
+
 const toProperty = (row: ClientListRow): Property => {
-  const [addressLine, suburbRaw = ''] = (row.address ?? '').split(',')
-  const suburb = suburbRaw.trim()
+  const { addressLine, suburb, city } = parseAddress(row.address)
   const garbageDescription = describeBinFrequency('Garbage', row.red_freq, row.red_flip)
   const recyclingDescription = describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip)
   const compostDescription = describeBinFrequency('Compost', row.green_freq, row.green_flip)
@@ -337,9 +350,9 @@ const toProperty = (row: ClientListRow): Property => {
   return {
     id: row.property_id,
     name: addressLine || row.client_name || 'Property',
-    addressLine: (addressLine ?? '').trim(),
+    addressLine,
     suburb,
-    city: suburb,
+    city,
     status: isActive ? 'active' : 'paused',
     binTypes,
     binCounts: {

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -130,7 +130,16 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                 </header>
                 <div className="grid auto-rows-fr gap-4 md:grid-cols-2">
                   {groupProperties.map((property) => {
-                    const addressParts = [property.addressLine, property.suburb].filter((part) => part && part.trim().length > 0)
+                    const seenAddressParts = new Set<string>()
+                    const addressParts: string[] = []
+                    ;[property.addressLine, property.suburb, property.city].forEach((part) => {
+                      const trimmed = part?.trim()
+                      if (!trimmed) return
+                      const key = trimmed.toLowerCase()
+                      if (seenAddressParts.has(key)) return
+                      seenAddressParts.add(key)
+                      addressParts.push(trimmed)
+                    })
                     const address = addressParts.join(', ')
                     const binSummaries: Array<{
                       key: 'garbage' | 'recycling' | 'compost'


### PR DESCRIPTION
## Summary
- normalise client portal addresses from Supabase to retain suburb and city portions
- ensure property cards render addresses without duplicated parts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e36db25d5c8332bc6e94e9c585ce3f