### PR TITLE
Enhance client tracker and job history views

### DIFF
--- a/components/client/ClientPortalProvider.tsx
+++ b/components/client/ClientPortalProvider.tsx
@@ -70,6 +70,7 @@ export type Job = {
   completedAt?: string | null
   crewName?: string | null
   proofPhotoKeys?: string[] | null
+  proofUploadedAt?: string | null
   routePolyline?: string | null
   lastLatitude?: number | null
   lastLongitude?: number | null
@@ -730,6 +731,7 @@ export function ClientPortalProvider({ children }: { children: React.ReactNode }
       }
 
       const completedAtIso = parseDateToIso(log.done_on ?? log.created_at)
+      const uploadedAtIso = parseDateToIso(log.created_at)
       if (!completedAtIso) {
         return
       }
@@ -746,6 +748,7 @@ export function ClientPortalProvider({ children }: { children: React.ReactNode }
         completedAt: completedAtIso,
         crewName: null,
         proofPhotoKeys: log.photo_path ? [log.photo_path] : [],
+        proofUploadedAt: uploadedAtIso,
         routePolyline: null,
         lastLatitude: log.gps_lat ?? undefined,
         lastLongitude: log.gps_lng ?? undefined,
@@ -775,6 +778,7 @@ export function ClientPortalProvider({ children }: { children: React.ReactNode }
         return
       }
       const completedAtIso = parseDateToIso(latestLog?.done_on ?? job.last_completed_on)
+      const proofUploadedAtIso = latestLog ? parseDateToIso(latestLog.created_at) : null
       const status: JobStatus = completedAtIso
         ? 'completed'
         : latestLog
@@ -794,6 +798,7 @@ export function ClientPortalProvider({ children }: { children: React.ReactNode }
         completedAt: completedAtIso,
         crewName: null,
         proofPhotoKeys,
+        proofUploadedAt: proofUploadedAtIso,
         routePolyline: null,
         lastLatitude: job.lat ?? undefined,
         lastLongitude: job.lng ?? undefined,

--- a/components/client/JobHistoryTable.tsx
+++ b/components/client/JobHistoryTable.tsx
@@ -227,23 +227,23 @@ export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHist
       </div>
 
       <div className="relative overflow-x-auto rounded-3xl border border-white/10 bg-black/20">
-        <table className="min-w-[720px] w-full table-fixed divide-y divide-white/10 text-left text-sm">
+        <table className="min-w-[760px] w-full table-auto divide-y divide-white/10 text-left text-sm">
           <thead className="text-xs uppercase tracking-wide text-white/40">
             <tr>
-              <th scope="col" className="w-1/5 px-4 py-3">
+              <th scope="col" className="px-4 py-3">
                 Address
               </th>
-              <th scope="col" className="w-1/5 px-4 py-3">
+              <th scope="col" className="px-4 py-3">
                 Job
               </th>
-              <th scope="col" className="w-1/5 px-4 py-3 text-center">
-                Photo
-              </th>
-              <th scope="col" className="w-1/5 px-4 py-3">
+              <th scope="col" className="px-4 py-3">
                 Completed
               </th>
-              <th scope="col" className="w-1/5 px-4 py-3">
+              <th scope="col" className="px-4 py-3">
                 Notes
+              </th>
+              <th scope="col" className="px-4 py-3 text-center">
+                Photo
               </th>
             </tr>
           </thead>
@@ -257,28 +257,49 @@ export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHist
             ) : (
               filteredJobs.map((job) => (
                 <tr key={job.id} className="hover:bg-white/5">
-                  <td className="w-1/5 px-4 py-3 align-top text-white">
+                  <td className="min-w-[220px] px-4 py-4 align-middle text-white">
                     {(() => {
                       const property = job.propertyId ? propertyMap.get(job.propertyId) : undefined
                       const propertyName = property?.name ?? job.propertyName
                       const fullAddress = formatAddress(property) ?? job.propertyName
                       return (
                         <>
-                          <div className="font-semibold">{propertyName}</div>
+                          <div className="font-semibold truncate">{propertyName}</div>
                           {fullAddress && (
-                            <p className="mt-1 text-xs text-white/60">{fullAddress}</p>
+                            <p
+                              className="mt-1 max-w-xs text-xs text-white/60"
+                              style={{
+                                display: '-webkit-box',
+                                WebkitLineClamp: '2',
+                                WebkitBoxOrient: 'vertical',
+                                overflow: 'hidden',
+                              }}
+                            >
+                              {fullAddress}
+                            </p>
                           )}
                         </>
                       )
                     })()}
                   </td>
-                  <td className="w-1/5 px-4 py-3 align-top text-white">
+                  <td className="px-4 py-4 align-middle text-white">
                     <div className="font-semibold">{formatJobTypeLabel(job.jobType)}</div>
                     <p className="mt-1 text-xs text-white/60">
                       {job.bins && job.bins.length > 0 ? job.bins.join(', ') : 'No bins recorded'}
                     </p>
                   </td>
-                  <td className="w-1/5 px-4 py-3 text-center">
+                  <td className="px-4 py-4 align-middle text-white/70">
+                    {(() => {
+                      const proofUploadedAt = job.proofUploadedAt
+                        ? new Date(job.proofUploadedAt)
+                        : job.completedAt
+                          ? new Date(job.completedAt)
+                          : null
+                      return proofUploadedAt ? format(proofUploadedAt, 'PP p') : '—'
+                    })()}
+                  </td>
+                  <td className="px-4 py-4 align-middle text-white/60">{job.notes ?? '—'}</td>
+                  <td className="px-4 py-4 align-middle text-center">
                     <button
                       type="button"
                       onClick={() => setProofJob(job)}
@@ -288,10 +309,6 @@ export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHist
                       <PhotoIcon className="h-4 w-4" /> View
                     </button>
                   </td>
-                  <td className="w-1/5 px-4 py-3 align-top text-white/70">
-                    {job.completedAt ? format(new Date(job.completedAt), 'PP p') : '—'}
-                  </td>
-                  <td className="w-1/5 px-4 py-3 align-top text-white/60">{job.notes ?? '—'}</td>
                 </tr>
               ))
             )}


### PR DESCRIPTION
## Summary
- ensure live tracker addresses omit duplicate suburb/city values and display bin types as coloured pills that mirror the proof page styling
- surface proof upload timestamps in job history while centring key columns and re-ordering the photo column
- prevent address text from wrapping excessively by clamping to two lines and letting the table grow naturally

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e36ffb5a608332b9768789e43fdc4d