### PR TITLE
Fix client dashboard layout

### DIFF
--- a/__tests__/JobHistoryTable.test.tsx
+++ b/__tests__/JobHistoryTable.test.tsx
@@ -8,6 +8,16 @@ vi.mock('@/components/client/ClientPortalProvider', () => ({
   useClientPortal: () => ({ selectedAccount: { name: 'Test account' } }),
 }))
 
+vi.mock('@/components/providers/SupabaseProvider', () => ({
+  useSupabase: () => ({
+    storage: {
+      from: () => ({
+        createSignedUrls: async () => ({ data: [], error: null }),
+      }),
+    },
+  }),
+}))
+
 const jobs: Job[] = [
   {
     id: '1',
@@ -58,6 +68,6 @@ describe('JobHistoryTable', () => {
     render(<JobHistoryTable jobs={jobs} properties={properties} />)
     const table = screen.getByRole('table')
     expect(within(table).getByText('Alpha')).toBeInTheDocument()
-    expect(within(table).getByText(/Test account/)).toBeInTheDocument()
+    expect(screen.getByText('Test account')).toBeInTheDocument()
   })
 })

--- a/__tests__/client/PropertyDashboard.test.tsx
+++ b/__tests__/client/PropertyDashboard.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PropertyDashboard } from '@/components/client/PropertyDashboard'
+import type { Property } from '@/components/client/ClientPortalProvider'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}))
+
+const baseProperty: Property = {
+  id: 'property-1',
+  name: 'BinBird HQ',
+  addressLine: '123 Sample Street',
+  suburb: 'Central',
+  city: 'Wellington',
+  status: 'active',
+  binTypes: ['garbage', 'recycling', 'compost'],
+  binCounts: {
+    garbage: 2,
+    recycling: 1,
+    compost: 1,
+    total: 4,
+  },
+  binDescriptions: {
+    garbage: 'Weekly (Mon) — front gate',
+    recycling: 'Fortnightly (Wed)',
+    compost: null,
+  },
+  nextServiceAt: '2024-06-01T00:00:00.000Z',
+  latitude: null,
+  longitude: null,
+  pricePerMonth: null,
+  trialStart: null,
+  membershipStart: null,
+  notes: null,
+  putOutDay: 'Tuesday',
+  collectionDay: 'Wednesday',
+}
+
+describe('PropertyDashboard', () => {
+  it('renders inline bin summaries with bold counts and unique address lines', () => {
+    render(<PropertyDashboard isLoading={false} properties={[baseProperty]} />)
+
+    const address = '123 Sample Street, Central, Wellington'
+    expect(screen.getAllByText(address)).toHaveLength(1)
+
+    const card = screen.getByRole('button', { name: 'View job history for BinBird HQ' })
+
+    const garbageSummary = within(card).getByText((content, node) => node?.textContent === '2 Garbage Bins')
+    expect(garbageSummary).toHaveClass('whitespace-nowrap')
+
+    const boldCount = within(garbageSummary).getByText('2')
+    expect(boldCount).toHaveClass('font-semibold', { exact: false })
+
+    expect(within(card).getByText((content, node) => node?.textContent === '1 Recycling Bin')).toBeInTheDocument()
+    expect(within(card).getByText((content, node) => node?.textContent === '1 Compost Bin')).toBeInTheDocument()
+
+    expect(within(card).getByText((content, node) => node?.textContent === '4 Total Bins')).toBeInTheDocument()
+  })
+})

--- a/__tests__/client/PropertyFilters.test.tsx
+++ b/__tests__/client/PropertyFilters.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PropertyFilters } from '@/components/client/PropertyFilters'
+import type { Property } from '@/components/client/ClientPortalProvider'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}))
+
+const sampleProperty = (overrides: Partial<Property>): Property => ({
+  id: 'property-id',
+  name: 'Sample Property',
+  addressLine: '1 Test Road',
+  suburb: 'Central',
+  city: 'Auckland',
+  status: 'active',
+  binTypes: ['garbage'],
+  binCounts: {
+    garbage: 3,
+    recycling: 2,
+    compost: 1,
+    total: 6,
+  },
+  binDescriptions: {
+    garbage: 'Weekly',
+    recycling: 'Fortnightly',
+    compost: 'Monthly',
+  },
+  nextServiceAt: null,
+  latitude: null,
+  longitude: null,
+  pricePerMonth: null,
+  trialStart: null,
+  membershipStart: null,
+  notes: null,
+  putOutDay: null,
+  collectionDay: null,
+  ...overrides,
+})
+
+describe('PropertyFilters', () => {
+  it('shows compact bin totals', () => {
+    const handleChange = vi.fn()
+
+    render(
+      <PropertyFilters
+        filters={{ search: '' }}
+        onChange={handleChange}
+        properties={[sampleProperty({ id: 'p1' }), sampleProperty({ id: 'p2' })]}
+      />,
+    )
+
+    expect(screen.getByText((content, node) => node?.textContent === '6 Garbage Bins')).toBeInTheDocument()
+    expect(screen.getByText((content, node) => node?.textContent === '4 Recycling Bins')).toBeInTheDocument()
+    expect(screen.getByText((content, node) => node?.textContent === '2 Compost Bins')).toBeInTheDocument()
+  })
+})

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,6 +36,10 @@ body {
   @apply text-white antialiased;
 }
 
+input[type='search']::-webkit-search-cancel-button {
+  filter: brightness(0) invert(1);
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -1,8 +1,7 @@
 
 'use client'
 
-import clsx from 'clsx'
-import { useCallback, useMemo, useState } from 'react'
+import { Fragment, useCallback, useMemo, useState } from 'react'
 import { format } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import type { Property } from './ClientPortalProvider'
@@ -41,23 +40,6 @@ function groupProperties(properties: Property[]) {
     groups[key] = groups[key] ? [...groups[key], property] : [property]
     return groups
   }, {})
-}
-
-const BIN_THEME: Record<
-  'garbage' | 'recycling' | 'compost',
-  {
-    panel: string
-  }
-> = {
-  garbage: {
-    panel: 'border-red-500/30 bg-red-500/5',
-  },
-  recycling: {
-    panel: 'border-yellow-400/40 bg-yellow-400/10',
-  },
-  compost: {
-    panel: 'border-green-500/30 bg-green-500/10',
-  },
 }
 
 const formatBinFrequency = (description: string | null) => {
@@ -141,6 +123,9 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                       addressParts.push(trimmed)
                     })
                     const address = addressParts.join(', ')
+                    const propertyName = property.name?.trim() ?? ''
+                    const title = propertyName || address || 'Unnamed property'
+                    const secondaryLine = address && address !== title ? address : ''
                     const binSummaries: Array<{
                       key: 'garbage' | 'recycling' | 'compost'
                       label: string
@@ -178,32 +163,32 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         <div className="flex flex-1 flex-col gap-5">
                           <div className="space-y-3">
                             <div className="space-y-2">
-                              <h4 className="text-xl font-semibold text-white">
-                                {address || property.name}
-                              </h4>
-                              {property.name && address && property.name !== address && (
-                                <p className="text-sm text-white/60">{property.name}</p>
-                              )}
+                              <h4 className="text-xl font-semibold text-white">{title}</h4>
+                              {secondaryLine && <p className="text-sm text-white/60">{secondaryLine}</p>}
                             </div>
-                            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                              {binSummaries.map((bin) => (
-                                <div
-                                  key={bin.key}
-                                  className={clsx(
-                                    'flex h-full min-h-[112px] flex-col justify-between rounded-2xl border px-4 py-5 transition-colors',
-                                    BIN_THEME[bin.key].panel,
-                                  )}
-                                >
-                                  <div className="space-y-1.5">
-                                    <p className="text-base font-semibold leading-tight text-white sm:text-lg">
-                                      {bin.count} {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
-                                    </p>
-                                    <p className="text-sm text-white/70">
-                                      {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
-                                    </p>
-                                  </div>
-                                </div>
-                              ))}
+                            <div className="space-y-2">
+                              <p className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-white/70">
+                                {binSummaries.map((bin, index) => (
+                                  <Fragment key={bin.key}>
+                                    <span className="whitespace-nowrap">
+                                      <span className="font-semibold text-white">{bin.count}</span>{' '}
+                                      {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
+                                    </span>
+                                    {index < binSummaries.length - 1 && (
+                                      <span className="text-white/40" aria-hidden>
+                                        ,{' '}
+                                      </span>
+                                    )}
+                                  </Fragment>
+                                ))}
+                              </p>
+                              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-white/50">
+                                {binSummaries.map((bin) => (
+                                  <span key={`${bin.key}-schedule`} className="whitespace-nowrap">
+                                    {bin.label}: {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
+                                  </span>
+                                ))}
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -218,9 +203,9 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                             Put out: {property.putOutDay ?? '—'} · Collection: {property.collectionDay ?? '—'}
                           </p>
                         </div>
-                        <div className="mt-6 flex items-center justify-between text-xs font-medium uppercase tracking-wide text-white/60">
+                        <div className="mt-6 flex flex-wrap items-center justify-between gap-3 text-xs font-medium tracking-wide text-white/60">
                           <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-white">
-                            Total bins: {property.binCounts.total}
+                            <span className="font-semibold text-white">{property.binCounts.total}</span> Total Bins
                           </span>
                           <span className="flex items-center gap-2 text-white/70 transition group-hover:text-white">
                             View job history <span aria-hidden>→</span>

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -127,16 +127,25 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
         </div>
         <dl className="grid flex-1 gap-3 sm:grid-cols-3 md:auto-cols-fr md:grid-flow-col">
           <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Garbage bins</dt>
-            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.garbage)}</dd>
+            <dt className="sr-only">Garbage bins</dt>
+            <dd className="text-sm text-white/70">
+              <span className="text-2xl font-semibold text-white">{formatBinTotal(totals.garbage)}</span>{' '}
+              Garbage Bins
+            </dd>
           </div>
           <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Recycling bins</dt>
-            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.recycling)}</dd>
+            <dt className="sr-only">Recycling bins</dt>
+            <dd className="text-sm text-white/70">
+              <span className="text-2xl font-semibold text-white">{formatBinTotal(totals.recycling)}</span>{' '}
+              Recycling Bins
+            </dd>
           </div>
           <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Compost bins</dt>
-            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.compost)}</dd>
+            <dt className="sr-only">Compost bins</dt>
+            <dd className="text-sm text-white/70">
+              <span className="text-2xl font-semibold text-white">{formatBinTotal(totals.compost)}</span>{' '}
+              Compost Bins
+            </dd>
           </div>
         </dl>
       </div>


### PR DESCRIPTION
## Summary
- render property cards with a single address line and inline bin summaries with bold counts
- show compact bin totals in the dashboard filter header and ensure the search clear icon matches the white theme
- add unit coverage for the dashboard and filter presentation and stub Supabase in the job history test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e41f59a5d083328da48545def455b7