### PR TITLE
Adjust next run date layout on staff run completion page

### DIFF
--- a/app/staff/run/completed/page.tsx
+++ b/app/staff/run/completed/page.tsx
@@ -445,8 +445,9 @@ function CompletedRunContent() {
                       "remaining today."
                     ) : (
                       <>
-                        awaiting on {nextAssignment.dateParts.weekday},
-                        {" "}
+                        awaiting on:
+                        <br />
+                        {nextAssignment.dateParts.weekday},{" "}
                         {nextAssignment.dateParts.month}{" "}
                         {nextAssignment.dateParts.day}
                         <sup>{nextAssignment.dateParts.ordinalSuffix}</sup>.


### PR DESCRIPTION
## Summary
- adjust layout of upcoming run text to place the date on a new line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e428e8e7788332a7bf5cae2a9a7de6