### PR TITLE
Enhance client tracker bin styling for consistency

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -7,6 +7,7 @@ import { format } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import type { Property } from './ClientPortalProvider'
 import { PropertyFilters, type PropertyFilterState } from './PropertyFilters'
+import { BIN_THEME, type BinThemeKey } from './binThemes'
 
 const DEFAULT_FILTERS: PropertyFilterState = {
   search: '',
@@ -41,23 +42,6 @@ function groupProperties(properties: Property[]) {
     groups[key] = groups[key] ? [...groups[key], property] : [property]
     return groups
   }, {})
-}
-
-const BIN_THEME: Record<
-  'garbage' | 'recycling' | 'compost',
-  {
-    panel: string
-  }
-> = {
-  garbage: {
-    panel: 'border-red-500/30 bg-red-500/5',
-  },
-  recycling: {
-    panel: 'border-yellow-400/40 bg-yellow-400/10',
-  },
-  compost: {
-    panel: 'border-green-500/30 bg-green-500/10',
-  },
 }
 
 const formatBinFrequency = (description: string | null) => {
@@ -142,7 +126,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                     })
                     const address = addressParts.join(', ')
                     const binSummaries: Array<{
-                      key: 'garbage' | 'recycling' | 'compost'
+                      key: BinThemeKey
                       label: string
                       count: number
                       description: string

--- a/components/client/binThemes.ts
+++ b/components/client/binThemes.ts
@@ -1,0 +1,18 @@
+export type BinThemeKey = 'garbage' | 'recycling' | 'compost'
+
+export const BIN_THEME: Record<BinThemeKey, { panel: string; pill: string }> = {
+  garbage: {
+    panel: 'border-red-500/30 bg-red-500/5',
+    pill: 'border-red-500/40 bg-red-500/15 text-white',
+  },
+  recycling: {
+    panel: 'border-yellow-400/40 bg-yellow-400/10',
+    pill: 'border-yellow-300/50 bg-yellow-300/20 text-white',
+  },
+  compost: {
+    panel: 'border-green-500/30 bg-green-500/10',
+    pill: 'border-emerald-400/40 bg-emerald-400/15 text-white',
+  },
+}
+
+export const DEFAULT_BIN_PILL = 'border-white/15 bg-white/10 text-white/80'


### PR DESCRIPTION
## Summary
- share bin color theming between dashboard and tracker views
- restyle tracker bin chips to match dashboard presentation and adapt responsively
- improve tracker progress status layout with a compact mobile-friendly grid

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e42a3d11d48332a15803292d3fa89c