### PR TITLE
Adjust client dashboard filters and bin summary layout

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -162,8 +162,8 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         className="group flex h-full min-h-[280px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[320px] sm:p-6 lg:min-h-[360px]"
                         aria-label={`View job history for ${property.name}`}
                       >
-                        <div className="flex flex-1 flex-col gap-5">
-                          <div className="space-y-3">
+                        <div className="flex flex-1 flex-col gap-4">
+                          <div className="space-y-2 sm:space-y-3">
                             <div className="space-y-2">
                               <h4 className="text-xl font-semibold text-white">
                                 {address || property.name}
@@ -177,33 +177,33 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                 <div
                                   key={bin.key}
                                   className={clsx(
-                                    'flex h-full min-h-[72px] min-w-0 flex-col justify-between rounded-2xl border px-3 py-2 text-xs transition-colors sm:px-4 sm:py-3 sm:text-sm',
+                                    'flex h-full min-h-[72px] min-w-0 flex-col justify-center gap-2 rounded-2xl border px-3 py-2 text-xs transition-colors sm:px-4 sm:py-3 sm:text-sm',
                                     BIN_THEME[bin.key].panel,
                                   )}
                                 >
-                                  <div className="space-y-1">
-                                    <p className="whitespace-nowrap text-sm font-semibold leading-tight text-white sm:text-base">
-                                      {bin.count} {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
-                                    </p>
-                                    <p className="text-xs text-white/70 sm:text-sm">
-                                      {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
-                                    </p>
-                                  </div>
+                                  <p className="whitespace-nowrap text-sm font-semibold leading-tight text-white sm:text-base">
+                                    {bin.count} {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
+                                  </p>
+                                  <p className="text-xs text-white/70 sm:text-sm">
+                                    {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
+                                  </p>
                                 </div>
                               ))}
                             </div>
+                            <div className="text-sm text-white/60">
+                              <p>
+                                Next service:
+                                <span className="ml-2 font-medium text-white">
+                                  {property.nextServiceAt
+                                    ? format(new Date(property.nextServiceAt), 'EEE, MMM d')
+                                    : 'Awaiting schedule'}
+                                </span>
+                              </p>
+                              <p className="text-xs text-white/50">
+                                Put out: {property.putOutDay ?? '—'} · Collection: {property.collectionDay ?? '—'}
+                              </p>
+                            </div>
                           </div>
-                        </div>
-                        <div className="mt-4 space-y-2 text-sm text-white/60">
-                          <p>
-                            Next service:
-                            <span className="ml-2 font-medium text-white">
-                              {property.nextServiceAt ? format(new Date(property.nextServiceAt), 'EEE, MMM d') : 'Awaiting schedule'}
-                            </span>
-                          </p>
-                          <p className="text-xs text-white/50">
-                            Put out: {property.putOutDay ?? '—'} · Collection: {property.collectionDay ?? '—'}
-                          </p>
                         </div>
                         <div className="mt-6 flex items-center justify-between text-xs font-medium uppercase tracking-wide text-white/60">
                           <span className="text-white/70">

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -172,20 +172,20 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                 <p className="text-sm text-white/60">{property.name}</p>
                               )}
                             </div>
-                            <div className="grid grid-cols-1 gap-3 sm:[grid-template-columns:repeat(auto-fit,minmax(180px,1fr))]">
+                            <div className="grid grid-cols-3 gap-2 sm:gap-3">
                               {binSummaries.map((bin) => (
                                 <div
                                   key={bin.key}
                                   className={clsx(
-                                    'flex h-full min-h-[112px] flex-col justify-between rounded-2xl border px-4 py-5 transition-colors',
+                                    'flex h-full min-h-[80px] min-w-0 flex-col justify-between rounded-2xl border px-3 py-3 text-xs transition-colors sm:px-4 sm:py-4 sm:text-sm',
                                     BIN_THEME[bin.key].panel,
                                   )}
                                 >
-                                  <div className="space-y-1.5">
-                                    <p className="whitespace-nowrap text-base font-semibold leading-tight text-white sm:text-lg">
+                                  <div className="space-y-1">
+                                    <p className="whitespace-nowrap text-sm font-semibold leading-tight text-white sm:text-base">
                                       {bin.count} {bin.label} {bin.count === 1 ? 'Bin' : 'Bins'}
                                     </p>
-                                    <p className="text-sm text-white/70">
+                                    <p className="text-xs text-white/70 sm:text-sm">
                                       {bin.description === 'Schedule not set' ? 'Schedule not set' : bin.description}
                                     </p>
                                   </div>

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -172,12 +172,12 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                 <p className="text-sm text-white/60">{property.name}</p>
                               )}
                             </div>
-                            <div className="grid grid-cols-3 gap-2 sm:gap-3">
+                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-3">
                               {binSummaries.map((bin) => (
                                 <div
                                   key={bin.key}
                                   className={clsx(
-                                    'flex h-full min-h-[80px] min-w-0 flex-col justify-between rounded-2xl border px-3 py-3 text-xs transition-colors sm:px-4 sm:py-4 sm:text-sm',
+                                    'flex h-full min-h-[72px] min-w-0 flex-col justify-between rounded-2xl border px-3 py-2 text-xs transition-colors sm:px-4 sm:py-3 sm:text-sm',
                                     BIN_THEME[bin.key].panel,
                                   )}
                                 >
@@ -194,7 +194,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                             </div>
                           </div>
                         </div>
-                        <div className="mt-6 space-y-2 text-sm text-white/60">
+                        <div className="mt-4 space-y-2 text-sm text-white/60">
                           <p>
                             Next service:
                             <span className="ml-2 font-medium text-white">

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -162,8 +162,8 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         className="group flex h-full min-h-[280px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[320px] sm:p-6 lg:min-h-[360px]"
                         aria-label={`View job history for ${property.name}`}
                       >
-                        <div className="flex flex-1 flex-col gap-4">
-                          <div className="space-y-2 sm:space-y-3">
+                        <div className="flex flex-1 flex-col gap-6">
+                          <div className="flex flex-1 flex-col gap-4">
                             <div className="space-y-2">
                               <h4 className="text-xl font-semibold text-white">
                                 {address || property.name}
@@ -190,7 +190,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                                 </div>
                               ))}
                             </div>
-                            <div className="text-sm text-white/60">
+                            <div className="space-y-2 text-sm text-white/60">
                               <p>
                                 Next service:
                                 <span className="ml-2 font-medium text-white">
@@ -204,14 +204,14 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                               </p>
                             </div>
                           </div>
-                        </div>
-                        <div className="mt-6 flex items-center justify-between text-xs font-medium uppercase tracking-wide text-white/60">
-                          <span className="text-white/70">
-                            Total bins · <span className="text-white">{property.binCounts.total}</span>
-                          </span>
-                          <span className="flex items-center gap-2 text-white/70 transition group-hover:text-white">
-                            View job history <span aria-hidden>→</span>
-                          </span>
+                          <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-white/60">
+                            <span className="text-white/70">
+                              Total bins · <span className="text-white">{property.binCounts.total}</span>
+                            </span>
+                            <span className="flex items-center gap-2 text-white/70 transition group-hover:text-white">
+                              View job history <span aria-hidden>→</span>
+                            </span>
+                          </div>
                         </div>
                       </button>
                     )

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -118,17 +118,23 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
           </div>
         </div>
         <dl className="grid w-full gap-2 sm:max-w-xl sm:grid-cols-3 sm:gap-3">
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Garbage bins</dt>
-            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.garbage)}</dd>
+          <div
+            className="flex min-h-[44px] items-center justify-between rounded-2xl border border-white/10 bg-black/30 px-4 py-2"
+          >
+            <dt className="text-xs font-medium uppercase tracking-wide text-white/60">Garbage bins</dt>
+            <dd className="text-lg font-semibold">{formatBinTotal(totals.garbage)}</dd>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Recycling bins</dt>
-            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.recycling)}</dd>
+          <div
+            className="flex min-h-[44px] items-center justify-between rounded-2xl border border-white/10 bg-black/30 px-4 py-2"
+          >
+            <dt className="text-xs font-medium uppercase tracking-wide text-white/60">Recycling bins</dt>
+            <dd className="text-lg font-semibold">{formatBinTotal(totals.recycling)}</dd>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Compost bins</dt>
-            <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.compost)}</dd>
+          <div
+            className="flex min-h-[44px] items-center justify-between rounded-2xl border border-white/10 bg-black/30 px-4 py-2"
+          >
+            <dt className="text-xs font-medium uppercase tracking-wide text-white/60">Compost bins</dt>
+            <dd className="text-lg font-semibold">{formatBinTotal(totals.compost)}</dd>
           </div>
         </dl>
       </div>

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useId, useMemo } from 'react'
-import { FunnelIcon } from '@heroicons/react/24/outline'
 import type { Property } from './ClientPortalProvider'
 
 export type PropertyFilterState = {
@@ -86,24 +85,17 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
 
   return (
     <section className="rounded-3xl border border-white/10 bg-white/5 p-4 text-white shadow-inner shadow-black/30">
-      <div className="mb-4 flex items-center gap-2 text-sm text-white/60">
-        <FunnelIcon className="h-5 w-5" />
-        <span>Filter properties</span>
-      </div>
-      <div className="flex flex-col gap-6">
-        <div className="flex w-full flex-col gap-2 text-sm">
-          <label className="text-white/60" htmlFor={searchInputId}>
-            Search
-          </label>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="w-full sm:max-w-md">
           <div className="relative">
             <input
               id={searchInputId}
               type="search"
               autoComplete="off"
-              placeholder="Search for property address"
+              placeholder="Search properties"
               value={filters.search}
               onChange={(event) => update({ search: event.target.value })}
-              className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
             />
             {matchingSuggestions.length > 0 && (
               <ul className="absolute left-0 right-0 z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-white/10 bg-black/80 p-2 backdrop-blur">
@@ -125,7 +117,7 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
             )}
           </div>
         </div>
-        <dl className="grid gap-3 sm:grid-cols-3">
+        <dl className="grid w-full gap-2 sm:max-w-xl sm:grid-cols-3 sm:gap-3">
           <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
             <dt className="text-xs uppercase tracking-wide text-white/50">Garbage bins</dt>
             <dd className="mt-1 text-2xl font-semibold">{formatBinTotal(totals.garbage)}</dd>

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -95,7 +95,7 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
               placeholder="Search properties"
               value={filters.search}
               onChange={(event) => update({ search: event.target.value })}
-              className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+              className="h-11 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
             />
             {matchingSuggestions.length > 0 && (
               <ul className="absolute left-0 right-0 z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-white/10 bg-black/80 p-2 backdrop-blur">


### PR DESCRIPTION
## Summary
- remove the filter header label, tighten spacing, and keep the search input prominent in the client dashboard filters
- shrink and align the per-bin summary cards into a single row so they take up less vertical space

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e439a41b808332a02d7f7f2d3f904f