### PR TITLE
Update client portal containers with dark translucent styling

### DIFF
--- a/components/client/AccountSwitcher.tsx
+++ b/components/client/AccountSwitcher.tsx
@@ -11,7 +11,7 @@ export function AccountSwitcher() {
 
   if (accounts.length <= 1 || !selectedAccount) {
     return (
-      <div className="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70">
+      <div className="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white/70">
         <UserCircleIcon className="h-5 w-5" />
         <div>
           <p className="font-medium text-white">{selectedAccount?.name ?? 'Primary Account'}</p>
@@ -25,7 +25,7 @@ export function AccountSwitcher() {
     <Listbox value={selectedAccount?.id} onChange={selectAccount}>
       {({ open }) => (
         <div className="relative w-full sm:max-w-xs">
-          <Listbox.Button className="relative flex w-full items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-left text-sm font-medium text-white shadow-lg shadow-black/20 transition hover:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30">
+          <Listbox.Button className="relative flex w-full items-center justify-between rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-left text-sm font-medium text-white shadow-lg shadow-black/20 transition hover:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30">
             <span className="flex flex-col">
               <span>{selectedAccount?.name}</span>
               <span className="text-xs uppercase tracking-wide text-white/50">{selectedAccount?.role}</span>

--- a/components/client/BillingOverview.tsx
+++ b/components/client/BillingOverview.tsx
@@ -67,7 +67,7 @@ export function BillingOverview() {
 
   return (
     <div className="space-y-6 text-white">
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-inner shadow-black/30">
+      <section className="rounded-3xl border border-white/10 bg-black/30 p-6 shadow-inner shadow-black/30">
         <div className="flex flex-col gap-2">
           <span className="text-xs uppercase tracking-wide text-white/50">Current plan</span>
           <h3 className="text-2xl font-semibold text-white">{planName}</h3>
@@ -95,7 +95,7 @@ export function BillingOverview() {
         </dl>
       </section>
 
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-inner shadow-black/30">
+      <section className="rounded-3xl border border-white/10 bg-black/30 p-6 shadow-inner shadow-black/30">
         <header className="mb-4 flex items-center justify-between text-sm text-white/60">
           <span className="inline-flex items-center gap-3">
             <CreditCardIcon className="h-5 w-5" /> Property billing summary

--- a/components/client/LiveTracker.tsx
+++ b/components/client/LiveTracker.tsx
@@ -137,7 +137,7 @@ export function LiveTracker() {
 
   return (
     <div className="space-y-6 text-white">
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-5">
+      <section className="rounded-3xl border border-white/10 bg-black/30 p-5">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-lg font-semibold text-white">Property map</h3>
@@ -149,7 +149,7 @@ export function LiveTracker() {
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-5">
+      <section className="rounded-3xl border border-white/10 bg-black/30 p-5">
         <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3 text-sm text-white/60">
             <UserGroupIcon className="h-5 w-5" />
@@ -189,7 +189,7 @@ export function LiveTracker() {
               return (
                 <article
                   key={job.id}
-                  className="rounded-3xl border border-white/10 bg-gradient-to-br from-black/60 via-black/40 to-black/20 p-6"
+                  className="rounded-3xl border border-white/10 bg-black/30 p-6"
                 >
                   <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
                     <div className="space-y-5">
@@ -250,17 +250,17 @@ export function LiveTracker() {
                             <div
                               key={`${job.id}-${step.key}-compact`}
                               className={clsx(
-                                'flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-left transition-colors',
+                                'flex flex-col gap-3 rounded-2xl border border-white/10 bg-black/30 p-4 text-left transition-colors',
                                 completed
                                   ? 'border-binbird-red/70 bg-binbird-red/10'
                                   : reached
                                     ? 'border-binbird-red/40 bg-binbird-red/5'
-                                    : 'border-white/10 bg-transparent',
+                                    : 'border-white/10 bg-black/20',
                               )}
                             >
                               <span
                                 className={clsx(
-                                  'flex h-10 w-10 items-center justify-center rounded-full border-2 text-sm font-semibold',
+                                'flex h-10 w-10 items-center justify-center rounded-full border-2 text-sm font-semibold',
                                   completed
                                     ? 'border-binbird-red bg-binbird-red text-binbird-black'
                                     : reached

--- a/components/client/NotificationPreferencesForm.tsx
+++ b/components/client/NotificationPreferencesForm.tsx
@@ -125,7 +125,7 @@ export function NotificationPreferencesForm() {
           return (
             <section
               key={field.key}
-              className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-5 shadow-inner shadow-black/30"
+              className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/30 p-5 shadow-inner shadow-black/30"
             >
               <div className="flex items-start gap-3">
                 <span className="rounded-2xl border border-white/20 bg-black/40 p-3 text-white/60">

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -95,7 +95,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
       <PropertyFilters filters={filters} onChange={setFilters} properties={properties} />
 
       {isLoading ? (
-        <div className="flex min-h-[200px] items-center justify-center rounded-3xl border border-white/10 bg-white/5">
+        <div className="flex min-h-[200px] items-center justify-center rounded-3xl border border-white/10 bg-black/30">
           <span className="flex items-center gap-3 text-white/60">
             <span className="h-2 w-2 animate-ping rounded-full bg-binbird-red" />
             Loading properties…
@@ -168,7 +168,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         key={property.id}
                         type="button"
                         onClick={() => handlePropertyClick(property.id)}
-                        className="group flex h-full min-h-[220px] flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-5 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[260px] sm:p-6"
+                        className="group flex h-full min-h-[220px] flex-col justify-between rounded-3xl border border-white/10 bg-black/30 p-5 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-h-[260px] sm:p-6"
                         aria-label={`View job history for ${property.name}`}
                       >
                         <div className="flex flex-1 flex-col gap-5">

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -70,7 +70,7 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
   }
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-white/5 p-4 text-white shadow-inner shadow-black/30">
+    <section className="rounded-3xl border border-white/10 bg-black/30 p-4 text-white shadow-inner shadow-black/30">
       <div className="w-full sm:max-w-md">
         <div className="relative">
           <input


### PR DESCRIPTION
## Summary
- restyle client portal filters, cards, and sections with translucent dark backgrounds that match the history view
- align live tracker progress cards, billing panels, and notification preferences with the new minimal border treatment
- update the account switcher container to share the same dark styling as the other client portal surfaces

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e461eb599083329583e3a6c31f7bf4