### PR TITLE
Handle flip bin schedules as alternate fortnight

### DIFF
--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -65,9 +65,17 @@ const getBinFrequencyInfo = (description: string | null) => {
   const cleaned = frequency.charAt(0).toUpperCase() + frequency.slice(1)
   const normalized = cleaned.toLowerCase()
 
+  const isFlip = normalized.includes('flip')
+  const isFortnightly = normalized.includes('fortnight')
+  const isWeekly = normalized.includes('week')
+
+  if (isFlip) {
+    return { label: 'Alternate Fortnight', showCalendarIcon: true }
+  }
+
   return {
     label: cleaned,
-    showCalendarIcon: normalized === 'fortnightly' || normalized === 'weekly',
+    showCalendarIcon: isFortnightly || isWeekly,
   }
 }
 


### PR DESCRIPTION
## Summary
- treat "flip" bin schedules in the property dashboard as alternate fortnight
- keep showing the calendar icon for fortnightly and weekly schedules by using keyword checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e488c8b2ec8332b5f7c62b3aed2dec