### PR TITLE
Hide dashboard search suggestions after interactions

### DIFF
--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useId, useMemo } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import type { Property } from './ClientPortalProvider'
 
 export type PropertyFilterState = {
@@ -49,6 +49,7 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
   }, [properties])
 
   const searchInputId = useId()
+  const [showSuggestions, setShowSuggestions] = useState(false)
   const matchingSuggestions = useMemo(() => {
     if (!filters.search) {
       return []
@@ -69,6 +70,12 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
     onChange({ ...filters, ...partial })
   }
 
+  useEffect(() => {
+    if (!filters.search.trim()) {
+      setShowSuggestions(false)
+    }
+  }, [filters.search])
+
   return (
     <div className="w-full">
       <div className="relative">
@@ -78,10 +85,27 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
           autoComplete="off"
           placeholder="Search for property address"
           value={filters.search}
-          onChange={(event) => update({ search: event.target.value })}
+          onChange={(event) => {
+            const value = event.target.value
+            update({ search: value })
+            setShowSuggestions(value.trim().length > 0)
+          }}
+          onFocus={() => {
+            if (filters.search.trim().length > 0) {
+              setShowSuggestions(true)
+            }
+          }}
+          onBlur={() => {
+            setShowSuggestions(false)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              setShowSuggestions(false)
+            }
+          }}
           className="h-11 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
         />
-        {matchingSuggestions.length > 0 && (
+        {showSuggestions && matchingSuggestions.length > 0 && (
           <ul className="absolute left-0 right-0 z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-white/10 bg-black/80 p-2 backdrop-blur">
             {matchingSuggestions.map((suggestion) => (
               <li key={suggestion}>
@@ -90,6 +114,7 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
                   onMouseDown={(event) => {
                     event.preventDefault()
                     update({ search: suggestion })
+                    setShowSuggestions(false)
                   }}
                   className="w-full rounded-xl px-3 py-2 text-left text-sm text-white transition hover:bg-binbird-red/20"
                 >


### PR DESCRIPTION
## Summary
- hide client dashboard search suggestions after selecting a result, pressing enter, or blurring the field
- ensure property list search suggestions close when the query is cleared or focus leaves the input

## Testing
- npm run dev *(fails: requires Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e48f35cba88332a198af9cc640ca84