### PR TITLE
Brighten client portal borders

### DIFF
--- a/app/client/(auth)/layout.tsx
+++ b/app/client/(auth)/layout.tsx
@@ -12,7 +12,7 @@ export default function ClientAuthLayout({ children }: { children: ReactNode }) 
             Sign in to BinBird to manage properties, track service progress, and keep your team aligned.
           </p>
         </div>
-        <div className="w-full rounded-3xl border border-white/10 bg-black/70 p-8 shadow-2xl backdrop-blur">
+        <div className="w-full rounded-3xl border border-white/20 bg-black/70 p-8 shadow-2xl backdrop-blur">
           {children}
         </div>
         <p className="mt-10 text-center text-xs text-white/50">

--- a/app/client/(auth)/login/page.tsx
+++ b/app/client/(auth)/login/page.tsx
@@ -66,7 +66,7 @@ export default function ClientLoginPage() {
             type="email"
             placeholder="Email"
             autoComplete="email"
-            className="w-full rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             required
@@ -77,7 +77,7 @@ export default function ClientLoginPage() {
           <label className="sr-only" htmlFor="password">
             Password
           </label>
-          <div className="flex items-center rounded-xl border border-white/10 bg-white/10 focus-within:border-binbird-red focus-within:ring-2 focus-within:ring-binbird-red/30">
+          <div className="flex items-center rounded-xl border border-white/20 bg-white/10 focus-within:border-binbird-red focus-within:ring-2 focus-within:ring-binbird-red/30">
             <input
               id="password"
               type={showPassword ? 'text' : 'password'}

--- a/app/client/(auth)/reset/page.tsx
+++ b/app/client/(auth)/reset/page.tsx
@@ -53,7 +53,7 @@ export default function ClientResetPasswordPage() {
           <input
             id="email"
             type="email"
-            className="mt-2 w-full rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-base text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             required

--- a/app/client/(portal)/history/page.tsx
+++ b/app/client/(portal)/history/page.tsx
@@ -18,7 +18,7 @@ export default function ClientHistoryPage() {
         </p>
       </div>
       {jobsLoading ? (
-        <div className="flex min-h-[200px] items-center justify-center rounded-3xl border border-white/10 bg-white/5 text-white/60">
+        <div className="flex min-h-[200px] items-center justify-center rounded-3xl border border-white/20 bg-white/5 text-white/60">
           <span className="flex items-center gap-3">
             <span className="h-2 w-2 animate-ping rounded-full bg-binbird-red" /> Loading job history…
           </span>

--- a/app/client/(portal)/layout.tsx
+++ b/app/client/(portal)/layout.tsx
@@ -23,7 +23,7 @@ function PortalScaffold({ children }: { children: ReactNode }) {
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-black px-4">
-        <div className="flex items-center gap-3 rounded-full border border-white/10 bg-black/70 px-6 py-3 text-white/70 shadow-lg shadow-black/30">
+        <div className="flex items-center gap-3 rounded-full border border-white/20 bg-black/70 px-6 py-3 text-white/70 shadow-lg shadow-black/30">
           <span className="h-2 w-2 animate-ping rounded-full bg-binbird-red" />
           Loading your portal…
         </div>
@@ -38,7 +38,7 @@ function PortalScaffold({ children }: { children: ReactNode }) {
         <PortalNavigation />
       </div>
       <div className="mx-auto mt-6 w-full max-w-6xl sm:mt-8">
-        <div className="rounded-3xl border border-white/10 bg-black/80 p-4 text-white shadow-2xl shadow-black/25 backdrop-blur sm:p-6">
+        <div className="rounded-3xl border border-white/20 bg-black/80 p-4 text-white shadow-2xl shadow-black/25 backdrop-blur sm:p-6">
           {children}
         </div>
       </div>

--- a/components/UI/PortalLoadingScreen.tsx
+++ b/components/UI/PortalLoadingScreen.tsx
@@ -9,7 +9,7 @@ interface PortalLoadingScreenProps {
 export function PortalLoadingScreen({ message = 'Loading your portal…' }: PortalLoadingScreenProps) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-black px-4">
-      <div className="flex items-center gap-3 rounded-full border border-white/10 bg-black/70 px-6 py-3 text-white/70 shadow-lg shadow-black/30">
+      <div className="flex items-center gap-3 rounded-full border border-white/20 bg-black/70 px-6 py-3 text-white/70 shadow-lg shadow-black/30">
         <span className="h-2 w-2 animate-ping rounded-full bg-binbird-red" />
         {message}
       </div>

--- a/components/UI/SettingsDrawer.tsx
+++ b/components/UI/SettingsDrawer.tsx
@@ -405,7 +405,7 @@ export default function SettingsDrawer() {
                                     "flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left text-base font-semibold uppercase tracking-wide transition",
                                     isSelected
                                       ? "border-white bg-white text-black shadow-sm"
-                                      : "border-white/15 text-white/70 hover:border-white/30 hover:text-white"
+                                      : "border-white/25 text-white/70 hover:border-white/35 hover:text-white"
                                   )}
                                   aria-pressed={isSelected}
                                 >
@@ -428,7 +428,7 @@ export default function SettingsDrawer() {
                                     "flex w-full items-center justify-between rounded-lg border px-4 py-3 text-left text-base font-semibold uppercase tracking-wide transition",
                                     isSelected
                                       ? "border-white bg-white text-black shadow-sm"
-                                      : "border-white/15 text-white/70 hover:border-white/30 hover:text-white"
+                                      : "border-white/25 text-white/70 hover:border-white/35 hover:text-white"
                                   )}
                                   aria-pressed={isSelected}
                                 >

--- a/components/client/AccountSwitcher.tsx
+++ b/components/client/AccountSwitcher.tsx
@@ -11,7 +11,7 @@ export function AccountSwitcher() {
 
   if (accounts.length <= 1 || !selectedAccount) {
     return (
-      <div className="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white/70">
+      <div className="flex w-full items-center gap-3 rounded-2xl border border-white/20 bg-black/30 px-4 py-2 text-sm text-white/70">
         <UserCircleIcon className="h-5 w-5" />
         <div>
           <p className="font-medium text-white">{selectedAccount?.name ?? 'Primary Account'}</p>
@@ -25,7 +25,7 @@ export function AccountSwitcher() {
     <Listbox value={selectedAccount?.id} onChange={selectAccount}>
       {({ open }) => (
         <div className="relative w-full sm:max-w-xs">
-          <Listbox.Button className="relative flex w-full items-center justify-between rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-left text-sm font-medium text-white shadow-lg shadow-black/20 transition hover:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30">
+          <Listbox.Button className="relative flex w-full items-center justify-between rounded-2xl border border-white/20 bg-black/30 px-4 py-2 text-left text-sm font-medium text-white shadow-lg shadow-black/20 transition hover:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30">
             <span className="flex flex-col">
               <span>{selectedAccount?.name}</span>
               <span className="text-xs uppercase tracking-wide text-white/50">{selectedAccount?.role}</span>
@@ -39,7 +39,7 @@ export function AccountSwitcher() {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <Listbox.Options className="absolute z-20 mt-2 w-full overflow-hidden rounded-2xl border border-white/10 bg-gray-900/95 p-1 text-sm text-white shadow-xl backdrop-blur">
+            <Listbox.Options className="absolute z-20 mt-2 w-full overflow-hidden rounded-2xl border border-white/20 bg-gray-900/95 p-1 text-sm text-white shadow-xl backdrop-blur">
               {accounts.map((account) => (
                 <Listbox.Option
                   key={account.id}

--- a/components/client/BillingOverview.tsx
+++ b/components/client/BillingOverview.tsx
@@ -67,7 +67,7 @@ export function BillingOverview() {
 
   return (
     <div className="space-y-6 text-white">
-      <section className="rounded-3xl border border-white/10 bg-black/30 p-6 shadow-inner shadow-black/30">
+      <section className="rounded-3xl border border-white/20 bg-black/30 p-6 shadow-inner shadow-black/30">
         <div className="flex flex-col gap-2">
           <span className="text-xs uppercase tracking-wide text-white/50">Current plan</span>
           <h3 className="text-2xl font-semibold text-white">{planName}</h3>
@@ -78,24 +78,24 @@ export function BillingOverview() {
           </p>
         </div>
         <dl className="mt-6 grid gap-4 sm:grid-cols-3">
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+          <div className="rounded-2xl border border-white/20 bg-black/30 p-4">
             <dt className="text-xs uppercase tracking-wide text-white/50">Monthly total</dt>
             <dd className="mt-1 text-2xl font-semibold">
               {stats.totalMonthly > 0 ? `$${stats.totalMonthly.toFixed(2)}` : 'Included'}
             </dd>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+          <div className="rounded-2xl border border-white/20 bg-black/30 p-4">
             <dt className="text-xs uppercase tracking-wide text-white/50">Active properties</dt>
             <dd className="mt-1 text-2xl font-semibold">{stats.activeProperties}</dd>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
+          <div className="rounded-2xl border border-white/20 bg-black/30 p-4">
             <dt className="text-xs uppercase tracking-wide text-white/50">On trial</dt>
             <dd className="mt-1 text-2xl font-semibold">{stats.trialProperties}</dd>
           </div>
         </dl>
       </section>
 
-      <section className="rounded-3xl border border-white/10 bg-black/30 p-6 shadow-inner shadow-black/30">
+      <section className="rounded-3xl border border-white/20 bg-black/30 p-6 shadow-inner shadow-black/30">
         <header className="mb-4 flex items-center justify-between text-sm text-white/60">
           <span className="inline-flex items-center gap-3">
             <CreditCardIcon className="h-5 w-5" /> Property billing summary
@@ -103,7 +103,7 @@ export function BillingOverview() {
           <button
             type="button"
             onClick={handleDownloadCsv}
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-xs font-medium uppercase tracking-wide text-white transition hover:border-binbird-red"
+            className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-xs font-medium uppercase tracking-wide text-white transition hover:border-binbird-red"
           >
             <ArrowDownTrayIcon className="h-4 w-4" /> Export CSV
           </button>

--- a/components/client/JobHistoryTable.tsx
+++ b/components/client/JobHistoryTable.tsx
@@ -220,7 +220,7 @@ export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHist
                 value={filters.search}
                 onChange={(event) => setFilters((current) => ({ ...current, search: event.target.value }))}
                 placeholder="Search for an address or property"
-                className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 pr-10 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30 md:min-w-[220px]"
+                className="w-full rounded-2xl border border-white/20 bg-black/40 px-4 py-2 pr-10 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30 md:min-w-[220px]"
                 id={searchInputId}
                 autoComplete="off"
               />
@@ -235,7 +235,7 @@ export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHist
                 </button>
               )}
               {matchingSuggestions.length > 0 && (
-                <ul className="absolute left-0 right-0 z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-white/10 bg-black/80 p-2 text-sm text-white shadow-lg backdrop-blur">
+                <ul className="absolute left-0 right-0 z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-white/20 bg-black/80 p-2 text-sm text-white shadow-lg backdrop-blur">
                   {matchingSuggestions.map((suggestion) => (
                     <li key={suggestion}>
                       <button
@@ -259,14 +259,14 @@ export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHist
           <button
             type="button"
             onClick={handleDownloadCsv}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red md:w-auto"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red md:w-auto"
           >
             <DocumentArrowDownIcon className="h-5 w-5" /> Export CSV
           </button>
         </div>
       </div>
 
-      <div className="relative overflow-x-auto rounded-3xl border border-white/10 bg-black/20">
+      <div className="relative overflow-x-auto rounded-3xl border border-white/20 bg-black/20">
         <table className="min-w-[760px] w-full table-auto divide-y divide-white/10 text-left text-sm">
           <thead className="text-xs uppercase tracking-wide text-white/40">
             <tr>
@@ -344,7 +344,7 @@ export function JobHistoryTable({ jobs, properties, initialPropertyId }: JobHist
                       type="button"
                       onClick={() => setProofJob(job)}
                       disabled={!job.proofPhotoKeys || job.proofPhotoKeys.length === 0}
-                      className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white transition hover:border-binbird-red disabled:cursor-not-allowed disabled:border-white/5 disabled:text-white/30"
+                      className="inline-flex items-center gap-2 rounded-full border border-white/20 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white transition hover:border-binbird-red disabled:cursor-not-allowed disabled:border-white/5 disabled:text-white/30"
                     >
                       <PhotoIcon className="h-4 w-4" /> View
                     </button>
@@ -388,7 +388,7 @@ function HistorySelect({ label, value, onChange, options, className }: HistorySe
       <Listbox value={value} onChange={onChange}>
         {({ open }) => (
           <div className="relative">
-            <Listbox.Button className="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-black/30 px-4 py-2 text-left text-sm text-white shadow-lg shadow-black/20 transition focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30">
+            <Listbox.Button className="flex w-full items-center justify-between rounded-2xl border border-white/20 bg-black/30 px-4 py-2 text-left text-sm text-white shadow-lg shadow-black/20 transition focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30">
               <span className="block truncate text-white/90">{selectedOption?.label}</span>
               <ChevronUpDownIcon className="h-4 w-4 text-white/60" aria-hidden="true" />
             </Listbox.Button>
@@ -399,7 +399,7 @@ function HistorySelect({ label, value, onChange, options, className }: HistorySe
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
             >
-              <Listbox.Options className="absolute z-20 mt-2 w-full overflow-hidden rounded-2xl border border-white/10 bg-black/90 p-1 text-sm text-white shadow-xl backdrop-blur">
+              <Listbox.Options className="absolute z-20 mt-2 w-full overflow-hidden rounded-2xl border border-white/20 bg-black/90 p-1 text-sm text-white shadow-xl backdrop-blur">
                 {options.map((option) => (
                   <Listbox.Option
                     key={option.value}

--- a/components/client/LiveTracker.tsx
+++ b/components/client/LiveTracker.tsx
@@ -137,7 +137,7 @@ export function LiveTracker() {
 
   return (
     <div className="space-y-6 text-white">
-      <section className="rounded-3xl border border-white/10 bg-black/30 p-5">
+      <section className="rounded-3xl border border-white/20 bg-black/30 p-5">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-lg font-semibold text-white">Property map</h3>
@@ -149,7 +149,7 @@ export function LiveTracker() {
         </div>
       </section>
 
-      <section className="rounded-3xl border border-white/10 bg-black/30 p-5">
+      <section className="rounded-3xl border border-white/20 bg-black/30 p-5">
         <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3 text-sm text-white/60">
             <UserGroupIcon className="h-5 w-5" />
@@ -160,7 +160,7 @@ export function LiveTracker() {
             onClick={() => {
               void handleRefresh()
             }}
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:text-white"
+            className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:text-white"
           >
             <BoltIcon className="h-5 w-5" /> Refresh data
           </button>
@@ -189,7 +189,7 @@ export function LiveTracker() {
               return (
                 <article
                   key={job.id}
-                  className="rounded-3xl border border-white/10 bg-black/30 p-6"
+                  className="rounded-3xl border border-white/20 bg-black/30 p-6"
                 >
                   <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
                     <div className="space-y-5">
@@ -250,12 +250,12 @@ export function LiveTracker() {
                             <div
                               key={`${job.id}-${step.key}-compact`}
                               className={clsx(
-                                'flex flex-col gap-3 rounded-2xl border border-white/10 bg-black/30 p-4 text-left transition-colors',
+                                'flex flex-col gap-3 rounded-2xl border border-white/20 bg-black/30 p-4 text-left transition-colors',
                                 completed
                                   ? 'border-binbird-red/70 bg-binbird-red/10'
                                   : reached
                                     ? 'border-binbird-red/40 bg-binbird-red/5'
-                                    : 'border-white/10 bg-black/20',
+                                    : 'border-white/20 bg-black/20',
                               )}
                             >
                               <span
@@ -265,7 +265,7 @@ export function LiveTracker() {
                                     ? 'border-binbird-red bg-binbird-red text-binbird-black'
                                     : reached
                                       ? 'border-binbird-red text-binbird-red'
-                                      : 'border-white/15 text-white/40',
+                                    : 'border-white/25 text-white/40',
                                 )}
                               >
                                 {completed ? <CheckIcon className="h-5 w-5" /> : index + 1}
@@ -298,7 +298,7 @@ export function LiveTracker() {
                                       ? 'border-binbird-red bg-binbird-red text-binbird-black'
                                       : reached
                                         ? 'border-binbird-red text-binbird-red'
-                                        : 'border-white/15 text-white/40',
+                                        : 'border-white/25 text-white/40',
                                   )}
                                 >
                                   {completed ? <CheckIcon className="h-6 w-6" /> : index + 1}

--- a/components/client/NotificationPreferencesForm.tsx
+++ b/components/client/NotificationPreferencesForm.tsx
@@ -125,7 +125,7 @@ export function NotificationPreferencesForm() {
           return (
             <section
               key={field.key}
-              className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/30 p-5 shadow-inner shadow-black/30"
+              className="flex flex-col gap-4 rounded-3xl border border-white/20 bg-black/30 p-5 shadow-inner shadow-black/30"
             >
               <div className="flex items-start gap-3">
                 <span className="rounded-2xl border border-white/20 bg-black/40 p-3 text-white/60">
@@ -137,7 +137,7 @@ export function NotificationPreferencesForm() {
                 </div>
               </div>
               <div className="grid gap-3 md:grid-cols-2">
-                <label className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm">
+                <label className="flex items-center justify-between gap-3 rounded-2xl border border-white/20 bg-black/40 px-4 py-3 text-sm">
                   <span className="text-white/70">Email</span>
                   <Switch
                     checked={formState[emailKey]}
@@ -156,7 +156,7 @@ export function NotificationPreferencesForm() {
                     />
                   </Switch>
                 </label>
-                <label className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm">
+                <label className="flex items-center justify-between gap-3 rounded-2xl border border-white/20 bg-black/40 px-4 py-3 text-sm">
                   <span className="text-white/70">Push</span>
                   <Switch
                     checked={formState[pushKey]}

--- a/components/client/PortalHeader.tsx
+++ b/components/client/PortalHeader.tsx
@@ -21,7 +21,7 @@ export function PortalHeader() {
   }
 
   return (
-    <header className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/70 p-4 text-white shadow-2xl shadow-black/30 backdrop-blur-lg sm:flex-row sm:items-center sm:justify-between sm:p-6">
+    <header className="flex flex-col gap-4 rounded-3xl border border-white/20 bg-black/70 p-4 text-white shadow-2xl shadow-black/30 backdrop-blur-lg sm:flex-row sm:items-center sm:justify-between sm:p-6">
       <div>
         <p className="text-sm uppercase tracking-[0.45em] text-white/40">{greeting}</p>
         <h1 className="mt-2 text-2xl font-semibold text-white">

--- a/components/client/PortalNavigation.tsx
+++ b/components/client/PortalNavigation.tsx
@@ -25,7 +25,7 @@ export function PortalNavigation() {
   const pathname = usePathname()
 
   return (
-    <nav className="flex w-full flex-nowrap items-center gap-2 overflow-x-auto rounded-3xl border border-white/10 bg-black/60 p-2 text-sm text-white shadow-2xl shadow-black/20 backdrop-blur [-webkit-overflow-scrolling:touch] sm:flex-wrap sm:overflow-visible sm:snap-none snap-x snap-mandatory">
+    <nav className="flex w-full flex-nowrap items-center gap-2 overflow-x-auto rounded-3xl border border-white/20 bg-black/60 p-2 text-sm text-white shadow-2xl shadow-black/20 backdrop-blur [-webkit-overflow-scrolling:touch] sm:flex-wrap sm:overflow-visible sm:snap-none snap-x snap-mandatory">
       {NAV_ITEMS.map((item) => {
         const active = pathname.startsWith(item.href)
         return (

--- a/components/client/ProofGalleryModal.tsx
+++ b/components/client/ProofGalleryModal.tsx
@@ -83,7 +83,7 @@ export function ProofGalleryModal({ isOpen, photoKeys, onClose }: ProofGalleryMo
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-90"
             >
-              <Dialog.Panel className="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-white/10 bg-black/90 text-white shadow-2xl">
+              <Dialog.Panel className="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-white/20 bg-black/90 text-white shadow-2xl">
                 <div className="aspect-video w-full bg-black/60">
                   {loading ? (
                     <div className="flex h-full items-center justify-center text-white/70">

--- a/components/client/PropertyDashboard.tsx
+++ b/components/client/PropertyDashboard.tsx
@@ -101,7 +101,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
       <PropertyFilters filters={filters} onChange={setFilters} properties={properties} />
 
       {isLoading ? (
-        <div className="flex min-h-[200px] items-center justify-center rounded-3xl border border-white/10 bg-black/30">
+        <div className="flex min-h-[200px] items-center justify-center rounded-3xl border border-white/20 bg-black/30">
           <span className="flex items-center gap-3 text-white/60">
             <span className="h-2 w-2 animate-ping rounded-full bg-binbird-red" />
             Loading properties…
@@ -123,7 +123,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
               <section
                 key={groupName}
                 className={clsx(
-                  'relative overflow-hidden rounded-3xl border border-white/10 bg-black/25 px-6 py-6 shadow-[0_8px_30px_rgba(0,0,0,0.35)] backdrop-blur-sm',
+                  'relative overflow-hidden rounded-3xl border border-white/20 bg-black/25 px-6 py-6 shadow-[0_8px_30px_rgba(0,0,0,0.35)] backdrop-blur-sm',
                   'before:absolute before:inset-x-6 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/40 before:to-transparent before:opacity-80 before:content-[\'\']',
                   {
                     'mt-2': groupIndex > 0,
@@ -195,7 +195,7 @@ export function PropertyDashboard({ properties, isLoading }: PropertyDashboardPr
                         key={property.id}
                         type="button"
                         onClick={() => handlePropertyClick(property.id)}
-                        className="group flex h-full w-full flex-col rounded-3xl border border-white/10 bg-black/30 px-5 py-6 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:px-6"
+                        className="group flex h-full w-full flex-col rounded-3xl border border-white/20 bg-black/30 px-5 py-6 text-left transition hover:border-binbird-red hover:bg-binbird-red/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:px-6"
                         aria-label={`View job history for ${property.name}`}
                       >
                         <div className="flex flex-col gap-4">

--- a/components/client/PropertyFilters.tsx
+++ b/components/client/PropertyFilters.tsx
@@ -79,10 +79,10 @@ export function PropertyFilters({ filters, onChange, properties }: PropertyFilte
           placeholder="Search for property address"
           value={filters.search}
           onChange={(event) => update({ search: event.target.value })}
-          className="h-11 w-full rounded-2xl border border-white/10 bg-black/40 px-4 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+          className="h-11 w-full rounded-2xl border border-white/20 bg-black/40 px-4 text-sm text-white placeholder:text-white/40 focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
         />
         {matchingSuggestions.length > 0 && (
-          <ul className="absolute left-0 right-0 z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-white/10 bg-black/80 p-2 backdrop-blur">
+          <ul className="absolute left-0 right-0 z-10 mt-2 max-h-64 overflow-y-auto rounded-2xl border border-white/20 bg-black/80 p-2 backdrop-blur">
             {matchingSuggestions.map((suggestion) => (
               <li key={suggestion}>
                 <button

--- a/components/client/SettingsForm.tsx
+++ b/components/client/SettingsForm.tsx
@@ -98,7 +98,7 @@ export function SettingsForm() {
           <input
             type="text"
             {...register('fullName', { required: 'Your name is required.' })}
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="rounded-2xl border border-white/20 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
           />
           {errors.fullName && <span className="text-xs text-red-300">{errors.fullName.message}</span>}
         </label>
@@ -107,7 +107,7 @@ export function SettingsForm() {
           <input
             type="tel"
             {...register('phone')}
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="rounded-2xl border border-white/20 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
           />
         </label>
         <label className="flex flex-col gap-2 text-sm">
@@ -115,14 +115,14 @@ export function SettingsForm() {
           <input
             type="text"
             {...register('companyName')}
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="rounded-2xl border border-white/20 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
           />
         </label>
         <label className="flex flex-col gap-2 text-sm">
           <span className="text-white/60">Timezone</span>
           <select
             {...register('timezone')}
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="rounded-2xl border border-white/20 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
           >
             {TIMEZONES.map((zone) => (
               <option key={zone} value={zone}>
@@ -137,7 +137,7 @@ export function SettingsForm() {
             type="text"
             {...register('emergencyContact')}
             placeholder="Name & phone of on-site contact"
-            className="rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
+            className="rounded-2xl border border-white/20 bg-black/40 px-4 py-2 text-white focus:border-binbird-red focus:outline-none focus:ring-2 focus:ring-binbird-red/30"
           />
         </label>
       </div>

--- a/components/client/TrackerMap.tsx
+++ b/components/client/TrackerMap.tsx
@@ -161,7 +161,7 @@ export function TrackerMap({ properties }: TrackerMapProps) {
   }, [])
 
   return (
-    <div className="relative h-80 overflow-hidden rounded-3xl border border-white/10 bg-black/60">
+    <div className="relative h-80 overflow-hidden rounded-3xl border border-white/20 bg-black/60">
       {!apiKey ? (
         <div className="absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-white/60">
           Add a Google Maps API key to view your properties on the map.
@@ -231,10 +231,10 @@ export function TrackerMap({ properties }: TrackerMapProps) {
                     onClick={(event) => event.stopPropagation()}
                   >
                     <div className="flex flex-col items-center">
-                      <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#0b0d12]/90 text-xs shadow-[0_18px_40px_rgba(0,0,0,0.55)] backdrop-blur-sm">
+                      <div className="overflow-hidden rounded-2xl border border-white/20 bg-[#0b0d12]/90 text-xs shadow-[0_18px_40px_rgba(0,0,0,0.55)] backdrop-blur-sm">
                         <AddressPopoverContent property={marker.property} />
                       </div>
-                      <div className="-mt-1 h-3 w-3 rotate-45 border border-white/10 bg-[#0b0d12]/90" />
+                      <div className="-mt-1 h-3 w-3 rotate-45 border border-white/20 bg-[#0b0d12]/90" />
                     </div>
                   </div>
                 </OverlayViewF>

--- a/components/client/binThemes.ts
+++ b/components/client/binThemes.ts
@@ -15,4 +15,4 @@ export const BIN_THEME: Record<BinThemeKey, { panel: string; pill: string }> = {
   },
 }
 
-export const DEFAULT_BIN_PILL = 'border-white/15 bg-white/10 text-white/80'
+export const DEFAULT_BIN_PILL = 'border-white/25 bg-white/10 text-white/80'


### PR DESCRIPTION
## Summary
- increase border contrast across the client portal layout, navigation, and cards for better visibility
- update related client portal components (filters, tables, modals, forms, and map overlays) to use the brighter border treatment
- align shared UI pieces such as the default bin pill and settings drawer toggles with the new border intensity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e48ef60c2c8332914e96e0033a1be9