### PR TITLE
Persist planned run progress between stops

### DIFF
--- a/app/staff/proof/proof-content.tsx
+++ b/app/staff/proof/proof-content.tsx
@@ -6,7 +6,7 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { getLocalISODate } from "@/lib/date";
 import { normalizeJobs, type Job } from "@/lib/jobs";
 import { readRunSession, writeRunSession, type RunSessionRecord } from "@/lib/run-session";
-import { clearPlannedRun } from "@/lib/planned-run";
+import { clearPlannedRun, readPlannedRun, writePlannedRun } from "@/lib/planned-run";
 
 const TRANSPARENT_PIXEL =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
@@ -335,6 +335,15 @@ export default function ProofPageContent() {
         clearPlannedRun();
         router.push("/staff/run/completed");
       } else {
+        const existingPlan = readPlannedRun();
+        if (existingPlan) {
+          writePlannedRun({
+            ...existingPlan,
+            jobs: jobs.map((plannedJob) => ({ ...plannedJob })),
+            nextIdx,
+            hasStarted: true,
+          });
+        }
         const paramsObj = new URLSearchParams({
           jobs: JSON.stringify(jobs),
           nextIdx: String(nextIdx),

--- a/app/staff/route/route-content.tsx
+++ b/app/staff/route/route-content.tsx
@@ -8,7 +8,7 @@ import { darkMapStyle, lightMapStyle, satelliteMapStyle } from "@/lib/mapStyle";
 import { MapSettingsProvider, useMapSettings } from "@/components/Context/MapSettingsContext";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { normalizeJobs, type Job } from "@/lib/jobs";
-import { readPlannedRun } from "@/lib/planned-run";
+import { readPlannedRun, writePlannedRun } from "@/lib/planned-run";
 
 function RoutePageContent() {
   const supabase = createClientComponentClient();
@@ -81,6 +81,14 @@ function RoutePageContent() {
         setLockNavigation(Boolean(stored.hasStarted));
         setJobs(stored.jobs.map((job) => ({ ...job })));
         setStart({ lat: stored.start.lat, lng: stored.start.lng });
+
+        if (!params.has("nextIdx") && stored.jobs.length) {
+          const clampedIdx = Math.min(
+            Math.max(stored.nextIdx ?? 0, 0),
+            Math.max(stored.jobs.length - 1, 0)
+          );
+          setActiveIdx(clampedIdx);
+        }
         return;
       }
       setLockNavigation(false);
@@ -133,6 +141,27 @@ function RoutePageContent() {
       if (!isNaN(parsed)) setActiveIdx(parsed);
     }
   }, [params]);
+
+  useEffect(() => {
+    if (!jobs.length || typeof window === "undefined") return;
+
+    const stored = readPlannedRun();
+    if (!stored) return;
+
+    const clampedIdx = Math.min(Math.max(activeIdx, 0), Math.max(jobs.length - 1, 0));
+    const storedIdx = Math.min(
+      Math.max(stored.nextIdx ?? 0, 0),
+      Math.max(stored.jobs.length - 1, 0)
+    );
+
+    if (storedIdx === clampedIdx) return;
+
+    writePlannedRun({
+      ...stored,
+      jobs: jobs.map((job) => ({ ...job })),
+      nextIdx: clampedIdx,
+    });
+  }, [activeIdx, jobs, jobs.length]);
 
   const activeJob = jobs[activeIdx];
   const previousJob = activeIdx > 0 ? jobs[activeIdx - 1] : null;

--- a/app/staff/run/run-content.tsx
+++ b/app/staff/run/run-content.tsx
@@ -399,6 +399,7 @@ function RunPageContent() {
         endAddress: normalizedEndAddress,
         createdAt: new Date().toISOString(),
         hasStarted: true,
+        nextIdx: 0,
       });
 
       hasRedirectedToRoute.current = true;
@@ -509,6 +510,7 @@ function RunPageContent() {
       endAddress: normalizedEndAddress,
       createdAt: new Date().toISOString(),
       hasStarted: false,
+      nextIdx: 0,
     });
 
     setPlannerLocked(true);

--- a/lib/planned-run.ts
+++ b/lib/planned-run.ts
@@ -11,6 +11,7 @@ export type PlannedRunPayload = {
   endAddress: string | null;
   createdAt: string;
   hasStarted: boolean;
+  nextIdx: number;
 };
 
 const PLANNED_RUN_STORAGE_KEY = "binbird:planned-run";
@@ -92,6 +93,14 @@ function normalizeJob(value: Job): Job {
   };
 }
 
+function normalizeNextIdx(value: unknown, jobsLength: number): number {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) return 0;
+  const numeric = Math.floor(numericValue);
+  if (jobsLength <= 0) return 0;
+  return Math.min(Math.max(numeric, 0), Math.max(jobsLength - 1, 0));
+}
+
 function parsePlannedRun(raw: string): PlannedRunPayload | null {
   try {
     const parsed = JSON.parse(raw) as Partial<PlannedRunPayload> | null;
@@ -114,6 +123,8 @@ function parsePlannedRun(raw: string): PlannedRunPayload | null {
       return null;
     }
 
+    const nextIdx = normalizeNextIdx(parsed.nextIdx ?? 0, normalizedJobs.length);
+
     return {
       start: parsed.start,
       end: parsed.end,
@@ -125,6 +136,7 @@ function parsePlannedRun(raw: string): PlannedRunPayload | null {
           ? parsed.createdAt
           : new Date().toISOString(),
       hasStarted: Boolean(parsed.hasStarted),
+      nextIdx,
     };
   } catch (err) {
     console.warn("Unable to parse planned run payload", err);
@@ -163,12 +175,14 @@ export function readPlannedRun(): PlannedRunPayload | null {
 export function writePlannedRun(payload: PlannedRunPayload) {
   const storages = getAvailableStorages();
 
+  const normalizedJobs = Array.isArray(payload.jobs)
+    ? payload.jobs.map((job) => normalizeJob(job))
+    : [];
+
   const normalized: PlannedRunPayload = {
     start: isLatLng(payload.start) ? payload.start : { lat: 0, lng: 0 },
     end: isLatLng(payload.end) ? payload.end : { lat: 0, lng: 0 },
-    jobs: Array.isArray(payload.jobs)
-      ? payload.jobs.map((job) => normalizeJob(job))
-      : [],
+    jobs: normalizedJobs,
     startAddress: normalizeAddress(payload.startAddress),
     endAddress: normalizeAddress(payload.endAddress),
     createdAt:
@@ -176,6 +190,7 @@ export function writePlannedRun(payload: PlannedRunPayload) {
         ? payload.createdAt
         : new Date().toISOString(),
     hasStarted: Boolean(payload.hasStarted),
+    nextIdx: normalizeNextIdx(payload.nextIdx ?? 0, normalizedJobs.length),
   };
 
   if (!normalized.jobs.length) {


### PR DESCRIPTION
## Summary
- add `nextIdx` tracking to the planned run payload so the current stop survives reloads
- sync the stored index whenever staff advance through the route or submit proof
- initialise new and resumed runs with a known `nextIdx` so progress persists across pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e55f5281c883328b499f13f1318589