### PR TITLE
Remove trailing period from next assignment date display

### DIFF
--- a/app/staff/run/completed/page.tsx
+++ b/app/staff/run/completed/page.tsx
@@ -450,7 +450,7 @@ function CompletedRunContent() {
                         {nextAssignment.dateParts.weekday},{" "}
                         {nextAssignment.dateParts.month}{" "}
                         {nextAssignment.dateParts.day}
-                        <sup>{nextAssignment.dateParts.ordinalSuffix}</sup>.
+                        <sup>{nextAssignment.dateParts.ordinalSuffix}</sup>
                       </>
                     )}
                   </p>


### PR DESCRIPTION
## Summary
- remove the trailing period after the next assignment date in the completed run view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5629e3a048332835e60a0b98ff656