### PR TITLE
Refresh client portal styling

### DIFF
--- a/app/client/(portal)/layout.tsx
+++ b/app/client/(portal)/layout.tsx
@@ -11,8 +11,8 @@ function PortalScaffold({ children }: { children: ReactNode }) {
 
   if (error) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-black px-4">
-        <div className="max-w-md rounded-3xl border border-red-500/40 bg-red-500/10 p-8 text-center text-red-100">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 px-4">
+        <div className="max-w-md rounded-3xl border border-red-500/30 bg-red-500/15 p-8 text-center text-red-100 shadow-2xl shadow-red-950/40 backdrop-blur">
           <h1 className="text-xl font-semibold">We could not load your portal</h1>
           <p className="mt-3 text-sm text-red-200/80">{error}</p>
         </div>
@@ -22,8 +22,8 @@ function PortalScaffold({ children }: { children: ReactNode }) {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-black px-4">
-        <div className="flex items-center gap-3 rounded-full border border-white/10 bg-black/70 px-6 py-3 text-white/70 shadow-lg shadow-black/30">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 px-4">
+        <div className="flex items-center gap-3 rounded-full border border-white/20 bg-slate-900/70 px-6 py-3 text-white/80 shadow-lg shadow-indigo-950/40 backdrop-blur">
           <span className="h-2 w-2 animate-ping rounded-full bg-binbird-red" />
           Loading your portal…
         </div>
@@ -32,13 +32,13 @@ function PortalScaffold({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div className="relative min-h-screen bg-black px-4 pb-24 pt-8 text-white sm:px-6 sm:pb-12 sm:pt-12 lg:px-8">
+    <div className="relative min-h-screen bg-gradient-to-br from-[#0f172a] via-[#1e1b4b] to-[#020617] px-4 pb-24 pt-8 text-white sm:px-6 sm:pb-12 sm:pt-12 lg:px-8">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 sm:gap-8">
         <PortalHeader />
         <PortalNavigation />
       </div>
       <div className="mx-auto mt-6 w-full max-w-6xl sm:mt-8">
-        <div className="rounded-3xl border border-white/10 bg-black/80 p-4 text-white shadow-2xl shadow-black/25 backdrop-blur sm:p-6">
+        <div className="rounded-3xl border border-white/20 bg-white/10 p-4 text-white shadow-2xl shadow-indigo-950/40 backdrop-blur-lg sm:p-6">
           {children}
         </div>
       </div>

--- a/components/client/PortalHeader.tsx
+++ b/components/client/PortalHeader.tsx
@@ -21,20 +21,20 @@ export function PortalHeader() {
   }
 
   return (
-    <header className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-black/70 p-4 text-white shadow-2xl shadow-black/30 backdrop-blur-lg sm:flex-row sm:items-center sm:justify-between sm:p-6">
+    <header className="flex flex-col gap-4 rounded-3xl border border-white/15 bg-gradient-to-r from-white/10 via-white/5 to-transparent p-4 text-white shadow-2xl shadow-indigo-950/30 backdrop-blur-xl sm:flex-row sm:items-center sm:justify-between sm:p-6">
       <div>
-        <p className="text-sm uppercase tracking-[0.45em] text-white/40">{greeting}</p>
+        <p className="text-sm uppercase tracking-[0.45em] text-indigo-200/80">{greeting}</p>
         <h1 className="mt-2 text-2xl font-semibold text-white">
           {profile?.fullName ?? user?.email ?? 'BinBird Client'}
         </h1>
-        {profile?.companyName && <p className="text-sm text-white/60">{profile.companyName}</p>}
+        {profile?.companyName && <p className="text-sm text-white/70">{profile.companyName}</p>}
       </div>
       <div className="flex flex-col items-stretch gap-3 sm:w-auto sm:flex-row sm:items-center">
         <AccountSwitcher />
         <button
           type="button"
           onClick={handleSignOut}
-          className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:bg-binbird-red/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:w-auto"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-white transition hover:border-binbird-red hover:bg-binbird-red/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:w-auto"
         >
           <ArrowRightOnRectangleIcon className="h-5 w-5" />
           Sign out

--- a/components/client/PortalNavigation.tsx
+++ b/components/client/PortalNavigation.tsx
@@ -25,7 +25,7 @@ export function PortalNavigation() {
   const pathname = usePathname()
 
   return (
-    <nav className="flex w-full flex-nowrap items-center gap-2 overflow-x-auto rounded-3xl border border-white/10 bg-black/60 p-2 text-sm text-white shadow-2xl shadow-black/20 backdrop-blur [-webkit-overflow-scrolling:touch] sm:flex-wrap sm:overflow-visible sm:snap-none snap-x snap-mandatory">
+    <nav className="flex w-full flex-nowrap items-center gap-2 overflow-x-auto rounded-3xl border border-white/15 bg-white/10 p-2 text-sm text-white shadow-xl shadow-indigo-950/30 backdrop-blur [-webkit-overflow-scrolling:touch] sm:flex-wrap sm:overflow-visible sm:snap-none snap-x snap-mandatory">
       {NAV_ITEMS.map((item) => {
         const active = pathname.startsWith(item.href)
         return (
@@ -34,7 +34,9 @@ export function PortalNavigation() {
             href={item.href}
             className={clsx(
               'flex min-w-[140px] flex-none snap-start items-center justify-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-binbird-red sm:min-w-0 sm:flex-1 sm:px-4',
-              active ? 'bg-binbird-red text-white shadow-lg shadow-red-900/40' : 'text-white/60 hover:text-white hover:bg-white/5',
+              active
+                ? 'bg-gradient-to-r from-binbird-red to-rose-500 text-white shadow-lg shadow-red-900/40'
+                : 'text-white/70 hover:text-white hover:bg-white/10 hover:shadow-md hover:shadow-indigo-950/30',
             )}
             aria-current={active ? 'page' : undefined}
           >


### PR DESCRIPTION
## Summary
- refresh the client portal scaffold with a luminous gradient background and softer loading/error states
- lighten the portal header and navigation surfaces with translucent glassmorphism accents
- enhance active navigation pill styling with a vibrant gradient highlight

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e57b2042788332bf6a4e893cd95c4c