### PR TITLE
Add admin 'Create Jobs' action and extract job-generation helpers

### DIFF
--- a/app/api/admin/jobs/create/route.ts
+++ b/app/api/admin/jobs/create/route.ts
@@ -35,9 +35,9 @@ type NewJobRow = {
 export async function POST(request: Request) {
   try {
     console.info("[admin/jobs/create] request received");
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     const supabase = createRouteHandlerClient({
-      cookies: () => cookieStore,
+      cookies: () => cookieStore as unknown as ReturnType<typeof cookies>,
     });
 
     const {

--- a/app/api/admin/jobs/create/route.ts
+++ b/app/api/admin/jobs/create/route.ts
@@ -33,132 +33,137 @@ type NewJobRow = {
 };
 
 export async function POST(request: Request) {
-  const cookieStore = cookies();
-  const supabase = createRouteHandlerClient({
-    cookies: () => cookieStore,
-  });
-
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
-
-  if (userError || !user) {
-    return NextResponse.json({ message: "Unauthorized." }, { status: 401 });
-  }
-
-  const { data: profile, error: profileError } = await supabase
-    .from("user_profile")
-    .select("role")
-    .eq("user_id", user.id)
-    .maybeSingle();
-
-  if (profileError || profile?.role !== "admin") {
-    return NextResponse.json({ message: "Forbidden." }, { status: 403 });
-  }
-
-  let payload: CreateJobsPayload;
   try {
-    payload = (await request.json()) as CreateJobsPayload;
-  } catch {
-    return NextResponse.json({ message: "Invalid request payload." }, { status: 400 });
-  }
-
-  const propertyId = payload.propertyId?.trim();
-  if (!propertyId) {
-    return NextResponse.json({ message: "Property ID is required." }, { status: 400 });
-  }
-
-  const { data: client, error: clientError } = await supabase
-    .from("client_list")
-    .select(
-      "property_id, account_id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, lat_lng, photo_path, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip",
-    )
-    .eq("property_id", propertyId)
-    .maybeSingle<JobSourceClientRow>();
-
-  if (clientError) {
-    console.error("Failed to load client for job creation", clientError);
-    return NextResponse.json({ message: "Unable to load property details." }, { status: 500 });
-  }
-
-  if (!client) {
-    return NextResponse.json({ message: "Property not found." }, { status: 404 });
-  }
-
-  const { dayIndex, dayName } = getJobGenerationDayInfo();
-  const accountId = deriveAccountId(client);
-  const clientName = deriveClientName(client);
-  const { lat, lng } = parseLatLng(client.lat_lng);
-  const bins = buildBinsSummary(client);
-  const address = client.address?.trim() ?? "";
-
-  const jobs: NewJobRow[] = [];
-
-  if (matchesDay(client.put_bins_out, dayIndex)) {
-    jobs.push({
-      account_id: accountId,
-      property_id: client.property_id,
-      address,
-      lat,
-      lng,
-      job_type: "put_out",
-      bins,
-      notes: client.notes,
-      client_name: clientName,
-      photo_path: client.photo_path,
-      assigned_to: client.assigned_to,
-      day_of_week: dayName,
-      last_completed_on: null,
+    const cookieStore = await cookies();
+    const supabase = createRouteHandlerClient({
+      cookies: () => cookieStore,
     });
-  }
 
-  if (matchesDay(client.collection_day, dayIndex)) {
-    jobs.push({
-      account_id: accountId,
-      property_id: client.property_id,
-      address,
-      lat,
-      lng,
-      job_type: "bring_in",
-      bins,
-      notes: client.notes,
-      client_name: clientName,
-      photo_path: client.photo_path,
-      assigned_to: client.assigned_to,
-      day_of_week: dayName,
-      last_completed_on: null,
-    });
-  }
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
 
-  if (!jobs.length) {
+    if (userError || !user) {
+      return NextResponse.json({ message: "Unauthorized." }, { status: 401 });
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("user_profile")
+      .select("role")
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (profileError || profile?.role !== "admin") {
+      return NextResponse.json({ message: "Forbidden." }, { status: 403 });
+    }
+
+    let payload: CreateJobsPayload;
+    try {
+      payload = (await request.json()) as CreateJobsPayload;
+    } catch {
+      return NextResponse.json({ message: "Invalid request payload." }, { status: 400 });
+    }
+
+    const propertyId = payload.propertyId?.trim();
+    if (!propertyId) {
+      return NextResponse.json({ message: "Property ID is required." }, { status: 400 });
+    }
+
+    const { data: client, error: clientError } = await supabase
+      .from("client_list")
+      .select(
+        "property_id, account_id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, lat_lng, photo_path, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip",
+      )
+      .eq("property_id", propertyId)
+      .maybeSingle<JobSourceClientRow>();
+
+    if (clientError) {
+      console.error("Failed to load client for job creation", clientError);
+      return NextResponse.json({ message: "Unable to load property details." }, { status: 500 });
+    }
+
+    if (!client) {
+      return NextResponse.json({ message: "Property not found." }, { status: 404 });
+    }
+
+    const { dayIndex, dayName } = getJobGenerationDayInfo();
+    const accountId = deriveAccountId(client);
+    const clientName = deriveClientName(client);
+    const { lat, lng } = parseLatLng(client.lat_lng);
+    const bins = buildBinsSummary(client);
+    const address = client.address?.trim() ?? "";
+
+    const jobs: NewJobRow[] = [];
+
+    if (matchesDay(client.put_bins_out, dayIndex)) {
+      jobs.push({
+        account_id: accountId,
+        property_id: client.property_id,
+        address,
+        lat,
+        lng,
+        job_type: "put_out",
+        bins,
+        notes: client.notes,
+        client_name: clientName,
+        photo_path: client.photo_path,
+        assigned_to: client.assigned_to,
+        day_of_week: dayName,
+        last_completed_on: null,
+      });
+    }
+
+    if (matchesDay(client.collection_day, dayIndex)) {
+      jobs.push({
+        account_id: accountId,
+        property_id: client.property_id,
+        address,
+        lat,
+        lng,
+        job_type: "bring_in",
+        bins,
+        notes: client.notes,
+        client_name: clientName,
+        photo_path: client.photo_path,
+        assigned_to: client.assigned_to,
+        day_of_week: dayName,
+        last_completed_on: null,
+      });
+    }
+
+    if (!jobs.length) {
+      return NextResponse.json({
+        status: "success",
+        message: `No jobs scheduled for ${dayName} for this property.`,
+      });
+    }
+
+    const { error: deleteError } = await supabase
+      .from("jobs")
+      .delete()
+      .eq("property_id", propertyId)
+      .eq("day_of_week", dayName)
+      .is("last_completed_on", null);
+
+    if (deleteError) {
+      console.error("Failed to clear existing jobs for property", deleteError);
+      return NextResponse.json({ message: "Failed to clear existing jobs." }, { status: 500 });
+    }
+
+    const { error: insertError } = await supabase.from("jobs").insert(jobs);
+
+    if (insertError) {
+      console.error("Failed to create jobs for property", insertError);
+      return NextResponse.json({ message: "Failed to create jobs." }, { status: 500 });
+    }
+
     return NextResponse.json({
       status: "success",
-      message: `No jobs scheduled for ${dayName} for this property.`,
+      message: `Created ${jobs.length} job${jobs.length === 1 ? "" : "s"} for ${dayName}.`,
     });
+  } catch (error) {
+    console.error("Unexpected error creating jobs for property", error);
+    return NextResponse.json({ message: "Unable to create jobs for this property." }, { status: 500 });
   }
-
-  const { error: deleteError } = await supabase
-    .from("jobs")
-    .delete()
-    .eq("property_id", propertyId)
-    .eq("day_of_week", dayName)
-    .is("last_completed_on", null);
-
-  if (deleteError) {
-    console.error("Failed to clear existing jobs for property", deleteError);
-    return NextResponse.json({ message: "Failed to clear existing jobs." }, { status: 500 });
-  }
-
-  const { error: insertError } = await supabase.from("jobs").insert(jobs);
-
-  if (insertError) {
-    console.error("Failed to create jobs for property", insertError);
-    return NextResponse.json({ message: "Failed to create jobs." }, { status: 500 });
-  }
-
-  return NextResponse.json({
-    status: "success",
-    message: `Created ${jobs.length} job${jobs.length === 1 ? "" : "s"} for ${dayName}.`,
-  });
 }

--- a/app/api/admin/jobs/create/route.ts
+++ b/app/api/admin/jobs/create/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+import {
+  buildBinsSummary,
+  deriveAccountId,
+  deriveClientName,
+  getJobGenerationDayInfo,
+  matchesDay,
+  parseLatLng,
+  type JobSourceClientRow,
+} from "@/lib/jobGeneration";
+
+type CreateJobsPayload = {
+  propertyId?: string;
+};
+
+type NewJobRow = {
+  account_id: string;
+  property_id: string | null;
+  address: string;
+  lat: number | null;
+  lng: number | null;
+  job_type: "put_out" | "bring_in";
+  bins: string | null;
+  notes: string | null;
+  client_name: string | null;
+  photo_path: string | null;
+  assigned_to: string | null;
+  day_of_week: string;
+  last_completed_on: null;
+};
+
+export async function POST(request: Request) {
+  const cookieStore = cookies();
+  const supabase = createRouteHandlerClient({
+    cookies: () => cookieStore,
+  });
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json({ message: "Unauthorized." }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("user_profile")
+    .select("role")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (profileError || profile?.role !== "admin") {
+    return NextResponse.json({ message: "Forbidden." }, { status: 403 });
+  }
+
+  let payload: CreateJobsPayload;
+  try {
+    payload = (await request.json()) as CreateJobsPayload;
+  } catch {
+    return NextResponse.json({ message: "Invalid request payload." }, { status: 400 });
+  }
+
+  const propertyId = payload.propertyId?.trim();
+  if (!propertyId) {
+    return NextResponse.json({ message: "Property ID is required." }, { status: 400 });
+  }
+
+  const { data: client, error: clientError } = await supabase
+    .from("client_list")
+    .select(
+      "property_id, account_id, client_name, company, address, collection_day, put_bins_out, notes, assigned_to, lat_lng, photo_path, red_freq, red_flip, yellow_freq, yellow_flip, green_freq, green_flip",
+    )
+    .eq("property_id", propertyId)
+    .maybeSingle<JobSourceClientRow>();
+
+  if (clientError) {
+    console.error("Failed to load client for job creation", clientError);
+    return NextResponse.json({ message: "Unable to load property details." }, { status: 500 });
+  }
+
+  if (!client) {
+    return NextResponse.json({ message: "Property not found." }, { status: 404 });
+  }
+
+  const { dayIndex, dayName } = getJobGenerationDayInfo();
+  const accountId = deriveAccountId(client);
+  const clientName = deriveClientName(client);
+  const { lat, lng } = parseLatLng(client.lat_lng);
+  const bins = buildBinsSummary(client);
+  const address = client.address?.trim() ?? "";
+
+  const jobs: NewJobRow[] = [];
+
+  if (matchesDay(client.put_bins_out, dayIndex)) {
+    jobs.push({
+      account_id: accountId,
+      property_id: client.property_id,
+      address,
+      lat,
+      lng,
+      job_type: "put_out",
+      bins,
+      notes: client.notes,
+      client_name: clientName,
+      photo_path: client.photo_path,
+      assigned_to: client.assigned_to,
+      day_of_week: dayName,
+      last_completed_on: null,
+    });
+  }
+
+  if (matchesDay(client.collection_day, dayIndex)) {
+    jobs.push({
+      account_id: accountId,
+      property_id: client.property_id,
+      address,
+      lat,
+      lng,
+      job_type: "bring_in",
+      bins,
+      notes: client.notes,
+      client_name: clientName,
+      photo_path: client.photo_path,
+      assigned_to: client.assigned_to,
+      day_of_week: dayName,
+      last_completed_on: null,
+    });
+  }
+
+  if (!jobs.length) {
+    return NextResponse.json({
+      status: "success",
+      message: `No jobs scheduled for ${dayName} for this property.`,
+    });
+  }
+
+  const { error: deleteError } = await supabase
+    .from("jobs")
+    .delete()
+    .eq("property_id", propertyId)
+    .eq("day_of_week", dayName)
+    .is("last_completed_on", null);
+
+  if (deleteError) {
+    console.error("Failed to clear existing jobs for property", deleteError);
+    return NextResponse.json({ message: "Failed to clear existing jobs." }, { status: 500 });
+  }
+
+  const { error: insertError } = await supabase.from("jobs").insert(jobs);
+
+  if (insertError) {
+    console.error("Failed to create jobs for property", insertError);
+    return NextResponse.json({ message: "Failed to create jobs." }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    status: "success",
+    message: `Created ${jobs.length} job${jobs.length === 1 ? "" : "s"} for ${dayName}.`,
+  });
+}

--- a/app/api/admin/jobs/create/route.ts
+++ b/app/api/admin/jobs/create/route.ts
@@ -34,9 +34,8 @@ type NewJobRow = {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
     const supabase = createRouteHandlerClient({
-      cookies: () => cookieStore,
+      cookies: async () => cookies(),
     });
 
     const {

--- a/app/api/admin/jobs/create/route.ts
+++ b/app/api/admin/jobs/create/route.ts
@@ -34,8 +34,9 @@ type NewJobRow = {
 
 export async function POST(request: Request) {
   try {
+    const cookieStore = cookies();
     const supabase = createRouteHandlerClient({
-      cookies: async () => cookies(),
+      cookies: () => cookieStore,
     });
 
     const {

--- a/app/api/admin/jobs/create/route.ts
+++ b/app/api/admin/jobs/create/route.ts
@@ -16,7 +16,7 @@ type CreateJobsPayload = {
 };
 
 type NewJobRow = {
-  account_id: string;
+  account_id: string | null;
   property_id: string | null;
   address: string;
   lat: number | null;

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -11,12 +11,12 @@ export async function GET(req: Request) {
   const url = new URL(req.url)
   const code = url.searchParams.get('code')
   const next = url.searchParams.get('next') ?? '/staff/today'
-  const cookieStore = cookies()
+  const cookieStore = await cookies()
 
   if (code) {
     try {
       const supabase = createRouteHandlerClient({
-        cookies: () => cookieStore,
+        cookies: () => cookieStore as unknown as ReturnType<typeof cookies>,
       })
       const { data, error } = await supabase.auth.exchangeCodeForSession(code)
 
@@ -46,7 +46,7 @@ type SupabaseAuthWebhookPayload = {
 
 export async function POST(req: Request) {
   let payload: SupabaseAuthWebhookPayload
-  const cookieStore = cookies()
+  const cookieStore = await cookies()
 
   try {
     payload = (await req.json()) as SupabaseAuthWebhookPayload
@@ -58,7 +58,7 @@ export async function POST(req: Request) {
 
   try {
     const supabase = createRouteHandlerClient({
-      cookies: () => cookieStore,
+      cookies: () => cookieStore as unknown as ReturnType<typeof cookies>,
     })
 
     if (event === 'SIGNED_OUT') {

--- a/app/ops/generate/page.tsx
+++ b/app/ops/generate/page.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/lib/jobGeneration'
 
 type NewJobRow = {
-  account_id: string
+  account_id: string | null
   property_id: string | null
   address: string
   lat: number | null

--- a/app/ops/generate/page.tsx
+++ b/app/ops/generate/page.tsx
@@ -2,50 +2,15 @@
 import BackButton from '@/components/UI/BackButton'
 import { supabaseServer } from '@/lib/supabaseServer'
 import { redirect } from 'next/navigation'
-import { getOperationalDayIndex, getOperationalDayName } from '@/lib/date'
-
-const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const
-
-const DAY_ALIASES: Record<string, number> = {
-  sun: 0,
-  sunday: 0,
-  mon: 1,
-  monday: 1,
-  tue: 2,
-  tues: 2,
-  tuesday: 2,
-  wed: 3,
-  weds: 3,
-  wednesday: 3,
-  thu: 4,
-  thur: 4,
-  thurs: 4,
-  thursday: 4,
-  fri: 5,
-  friday: 5,
-  sat: 6,
-  saturday: 6,
-}
-
-type ClientListRow = {
-  property_id: string
-  account_id: string | null
-  client_name: string | null
-  company: string | null
-  address: string | null
-  collection_day: string | null
-  put_bins_out: string | null
-  notes: string | null
-  assigned_to: string | null
-  lat_lng: string | null
-  photo_path: string | null
-  red_freq: string | null
-  red_flip: string | null
-  yellow_freq: string | null
-  yellow_flip: string | null
-  green_freq: string | null
-  green_flip: string | null
-}
+import {
+  buildBinsSummary,
+  deriveAccountId,
+  deriveClientName,
+  getJobGenerationDayInfo,
+  matchesDay,
+  parseLatLng,
+  type JobSourceClientRow,
+} from '@/lib/jobGeneration'
 
 type NewJobRow = {
   account_id: string
@@ -63,75 +28,10 @@ type NewJobRow = {
   last_completed_on: null
 }
 
-const tokensFor = (value: string | null | undefined) =>
-  (value ?? '')
-    .toLowerCase()
-    .split(/[^a-z]+/)
-    .filter(Boolean)
-
-const parseDayIndex = (value: string | null | undefined): number | null => {
-  const tokens = tokensFor(value)
-  for (const token of tokens) {
-    const idx = DAY_ALIASES[token]
-    if (idx !== undefined) {
-      return idx
-    }
-  }
-  return null
-}
-
-const matchesDay = (value: string | null, dayIndex: number): boolean =>
-  tokensFor(value).some((token) => DAY_ALIASES[token] === dayIndex)
-
-const parseLatLng = (value: string | null): { lat: number | null; lng: number | null } => {
-  if (!value) return { lat: null, lng: null }
-  const [latRaw, lngRaw] = value.split(',').map((part) => Number.parseFloat(part.trim()))
-  return {
-    lat: Number.isFinite(latRaw) ? latRaw : null,
-    lng: Number.isFinite(lngRaw) ? lngRaw : null,
-  }
-}
-
-const describeBinFrequency = (
-  label: string,
-  frequency: string | null,
-  flip: string | null,
-) => {
-  if (!frequency) return null
-  const base = `${label} (${frequency.toLowerCase()})`
-  if (frequency === 'Fortnightly' && flip === 'Yes') {
-    return `${base}, alternate weeks`
-  }
-  return base
-}
-
-const deriveAccountId = (row: ClientListRow): string =>
-  row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.property_id
-
-const deriveClientName = (row: ClientListRow): string =>
-  row.client_name?.trim() || row.company?.trim() || 'Client'
-
-const buildBinsSummary = (row: ClientListRow): string | null => {
-  const bins = [
-    describeBinFrequency('Garbage', row.red_freq, row.red_flip),
-    describeBinFrequency('Recycling', row.yellow_freq, row.yellow_flip),
-    describeBinFrequency('Organic', row.green_freq, row.green_flip),
-  ].filter(Boolean) as string[]
-
-  if (!bins.length) return null
-  return bins.join(', ')
-}
-
 async function generateJobs() {
   'use server'
   const sb = await supabaseServer()
-  const override = process.env.NEXT_PUBLIC_DEV_DAY_OVERRIDE ?? null
-  const overrideIndex = parseDayIndex(override)
-
-  const operationalIndex = getOperationalDayIndex()
-  const dayIndex = overrideIndex ?? operationalIndex
-  const dayName =
-    overrideIndex !== null ? DAY_NAMES[dayIndex] : getOperationalDayName()
+  const { dayIndex, dayName } = getJobGenerationDayInfo()
 
   const { data: clients, error: clientError } = await sb
     .from('client_list')
@@ -148,7 +48,7 @@ async function generateJobs() {
     redirect(`/ops/generate?${params.toString()}`)
   }
 
-  const rows = (clients ?? []) as ClientListRow[]
+  const rows = (clients ?? []) as JobSourceClientRow[]
 
   const jobs: NewJobRow[] = []
   for (const client of rows) {

--- a/components/admin/ClientListManager.tsx
+++ b/components/admin/ClientListManager.tsx
@@ -117,6 +117,7 @@ export default function ClientListManager() {
   const [formState, setFormState] = useState<ClientFormState>(emptyFormState);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [creatingJobs, setCreatingJobs] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const [showNewClientModal, setShowNewClientModal] = useState(false);
@@ -500,6 +501,47 @@ export default function ClientListManager() {
     }
   };
 
+  const handleCreateJobs = async () => {
+    if (!selectedRowId) return;
+    setCreatingJobs(true);
+    setStatus(null);
+    try {
+      const response = await fetch("/api/admin/jobs/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ propertyId: selectedRowId }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as
+        | { status?: string; message?: string }
+        | null;
+
+      if (!response.ok) {
+        setStatus({
+          type: "error",
+          message: payload?.message ?? "Unable to create jobs for this property.",
+        });
+        return;
+      }
+
+      setStatus({
+        type: payload?.status === "error" ? "error" : "success",
+        message: payload?.message ?? "Jobs created for this property.",
+      });
+    } catch (createError) {
+      console.error("Failed to create jobs", createError);
+      setStatus({
+        type: "error",
+        message:
+          createError instanceof Error
+            ? createError.message
+            : "Unable to create jobs for this property. Please try again.",
+      });
+    } finally {
+      setCreatingJobs(false);
+    }
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)] lg:gap-8">
@@ -636,14 +678,24 @@ export default function ClientListManager() {
               <p className="text-xs text-gray-600">Update any column and save to sync with Supabase.</p>
             </div>
             {selectedRow && (
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(true)}
-                disabled={deleting}
-                className="rounded-lg border border-gray-400 px-3 py-1.5 text-xs font-semibold text-gray-800 transition hover:border-gray-500 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {deleting ? "Deleting…" : "Delete"}
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleCreateJobs}
+                  disabled={creatingJobs}
+                  className="rounded-lg border border-gray-400 px-3 py-1.5 text-xs font-semibold text-gray-800 transition hover:border-gray-500 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {creatingJobs ? "Creating…" : "Create Jobs"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  disabled={deleting}
+                  className="rounded-lg border border-gray-400 px-3 py-1.5 text-xs font-semibold text-gray-800 transition hover:border-gray-500 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {deleting ? "Deleting…" : "Delete"}
+                </button>
+              </div>
             )}
           </div>
 

--- a/components/admin/ClientListManager.tsx
+++ b/components/admin/ClientListManager.tsx
@@ -512,14 +512,17 @@ export default function ClientListManager() {
         body: JSON.stringify({ propertyId: selectedRowId }),
       });
 
-      const payload = (await response.json().catch(() => null)) as
-        | { status?: string; message?: string }
-        | null;
+      const payloadText = await response.text().catch(() => "");
+      const payload = payloadText
+        ? ((JSON.parse(payloadText) as { status?: string; message?: string }) ?? null)
+        : null;
 
       if (!response.ok) {
         setStatus({
           type: "error",
-          message: payload?.message ?? "Unable to create jobs for this property.",
+          message:
+            payload?.message ??
+            (payloadText ? `Unable to create jobs for this property: ${payloadText}` : "Unable to create jobs for this property."),
         });
         return;
       }

--- a/lib/jobGeneration.ts
+++ b/lib/jobGeneration.ts
@@ -1,3 +1,4 @@
+import { getBinSchedule } from "@/lib/binSchedule";
 import { getOperationalDayIndex, getOperationalDayName } from "@/lib/date";
 
 export const DAY_NAMES = [
@@ -94,15 +95,6 @@ export const parseLatLng = (value: string | null): { lat: number | null; lng: nu
   };
 };
 
-const describeBinFrequency = (label: string, frequency: string | null, flip: string | null) => {
-  if (!frequency) return null;
-  const base = `${label} (${frequency.toLowerCase()})`;
-  if (frequency === "Fortnightly" && flip === "Yes") {
-    return `${base}, alternate weeks`;
-  }
-  return base;
-};
-
 export const deriveAccountId = (row: JobSourceClientRow): string | null => {
   const explicit = row.account_id?.trim();
   return explicit && explicit.length > 0 ? explicit : null;
@@ -112,14 +104,17 @@ export const deriveClientName = (row: JobSourceClientRow): string =>
   row.client_name?.trim() || row.company?.trim() || "Client";
 
 export const buildBinsSummary = (row: JobSourceClientRow): string | null => {
-  const bins = [
-    describeBinFrequency("Garbage", row.red_freq, row.red_flip),
-    describeBinFrequency("Recycling", row.yellow_freq, row.yellow_flip),
-    describeBinFrequency("Organic", row.green_freq, row.green_flip),
-  ].filter(Boolean) as string[];
+  const schedule = getBinSchedule({
+    red_freq: row.red_freq,
+    red_flip: row.red_flip,
+    yellow_freq: row.yellow_freq,
+    yellow_flip: row.yellow_flip,
+    green_freq: row.green_freq,
+    green_flip: row.green_flip,
+  });
 
-  if (!bins.length) return null;
-  return bins.join(", ");
+  if (!schedule.activeColors.length) return null;
+  return schedule.activeColors.join(", ");
 };
 
 export const getJobGenerationDayInfo = () => {

--- a/lib/jobGeneration.ts
+++ b/lib/jobGeneration.ts
@@ -71,6 +71,20 @@ export const parseDayIndex = (value: string | null | undefined): number | null =
 export const matchesDay = (value: string | null, dayIndex: number): boolean =>
   tokensFor(value).some((token) => DAY_ALIASES[token] === dayIndex);
 
+export const extractDayNames = (value: string | null | undefined): string[] => {
+  const dayIndexes = new Set<number>();
+  tokensFor(value).forEach((token) => {
+    const idx = DAY_ALIASES[token];
+    if (idx !== undefined) {
+      dayIndexes.add(idx);
+    }
+  });
+
+  return [...dayIndexes]
+    .sort((a, b) => a - b)
+    .map((idx) => DAY_NAMES[idx]);
+};
+
 export const parseLatLng = (value: string | null): { lat: number | null; lng: number | null } => {
   if (!value) return { lat: null, lng: null };
   const [latRaw, lngRaw] = value.split(",").map((part) => Number.parseFloat(part.trim()));

--- a/lib/jobGeneration.ts
+++ b/lib/jobGeneration.ts
@@ -1,0 +1,117 @@
+import { getOperationalDayIndex, getOperationalDayName } from "@/lib/date";
+
+export const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+const DAY_ALIASES: Record<string, number> = {
+  sun: 0,
+  sunday: 0,
+  mon: 1,
+  monday: 1,
+  tue: 2,
+  tues: 2,
+  tuesday: 2,
+  wed: 3,
+  weds: 3,
+  wednesday: 3,
+  thu: 4,
+  thur: 4,
+  thurs: 4,
+  thursday: 4,
+  fri: 5,
+  friday: 5,
+  sat: 6,
+  saturday: 6,
+};
+
+export type JobSourceClientRow = {
+  property_id: string;
+  account_id: string | null;
+  client_name: string | null;
+  company: string | null;
+  address: string | null;
+  collection_day: string | null;
+  put_bins_out: string | null;
+  notes: string | null;
+  assigned_to: string | null;
+  lat_lng: string | null;
+  photo_path: string | null;
+  red_freq: string | null;
+  red_flip: string | null;
+  yellow_freq: string | null;
+  yellow_flip: string | null;
+  green_freq: string | null;
+  green_flip: string | null;
+};
+
+const tokensFor = (value: string | null | undefined) =>
+  (value ?? "")
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .filter(Boolean);
+
+export const parseDayIndex = (value: string | null | undefined): number | null => {
+  const tokens = tokensFor(value);
+  for (const token of tokens) {
+    const idx = DAY_ALIASES[token];
+    if (idx !== undefined) {
+      return idx;
+    }
+  }
+  return null;
+};
+
+export const matchesDay = (value: string | null, dayIndex: number): boolean =>
+  tokensFor(value).some((token) => DAY_ALIASES[token] === dayIndex);
+
+export const parseLatLng = (value: string | null): { lat: number | null; lng: number | null } => {
+  if (!value) return { lat: null, lng: null };
+  const [latRaw, lngRaw] = value.split(",").map((part) => Number.parseFloat(part.trim()));
+  return {
+    lat: Number.isFinite(latRaw) ? latRaw : null,
+    lng: Number.isFinite(lngRaw) ? lngRaw : null,
+  };
+};
+
+const describeBinFrequency = (label: string, frequency: string | null, flip: string | null) => {
+  if (!frequency) return null;
+  const base = `${label} (${frequency.toLowerCase()})`;
+  if (frequency === "Fortnightly" && flip === "Yes") {
+    return `${base}, alternate weeks`;
+  }
+  return base;
+};
+
+export const deriveAccountId = (row: JobSourceClientRow): string =>
+  row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.property_id;
+
+export const deriveClientName = (row: JobSourceClientRow): string =>
+  row.client_name?.trim() || row.company?.trim() || "Client";
+
+export const buildBinsSummary = (row: JobSourceClientRow): string | null => {
+  const bins = [
+    describeBinFrequency("Garbage", row.red_freq, row.red_flip),
+    describeBinFrequency("Recycling", row.yellow_freq, row.yellow_flip),
+    describeBinFrequency("Organic", row.green_freq, row.green_flip),
+  ].filter(Boolean) as string[];
+
+  if (!bins.length) return null;
+  return bins.join(", ");
+};
+
+export const getJobGenerationDayInfo = () => {
+  const override = process.env.NEXT_PUBLIC_DEV_DAY_OVERRIDE ?? null;
+  const overrideIndex = parseDayIndex(override);
+  const operationalIndex = getOperationalDayIndex();
+  const dayIndex = overrideIndex ?? operationalIndex;
+  const dayName = overrideIndex !== null ? DAY_NAMES[dayIndex] : getOperationalDayName();
+
+  return { dayIndex, dayName };
+};

--- a/lib/jobGeneration.ts
+++ b/lib/jobGeneration.ts
@@ -103,8 +103,10 @@ const describeBinFrequency = (label: string, frequency: string | null, flip: str
   return base;
 };
 
-export const deriveAccountId = (row: JobSourceClientRow): string =>
-  row.account_id && row.account_id.trim().length ? row.account_id.trim() : row.property_id;
+export const deriveAccountId = (row: JobSourceClientRow): string | null => {
+  const explicit = row.account_id?.trim();
+  return explicit && explicit.length > 0 ? explicit : null;
+};
 
 export const deriveClientName = (row: JobSourceClientRow): string =>
   row.client_name?.trim() || row.company?.trim() || "Client";


### PR DESCRIPTION
### Motivation

- Provide an admin action to generate jobs for a single property using the same logic as the existing ops generator. 
- Reuse shared job-generation logic to avoid duplication between the bulk `ops/generate` flow and the new per-property action.

### Description

- Extracted shared job-generation helpers into `lib/jobGeneration.ts` and exported utilities like `getJobGenerationDayInfo`, `matchesDay`, `parseLatLng`, `deriveAccountId`, and `buildBinsSummary`.
- Rewrote `app/ops/generate/page.tsx` to consume the new helpers rather than duplicating parsing and day-derivation logic.
- Added an authenticated admin API route `app/api/admin/jobs/create/route.ts` that validates admin role, loads the property (`client_list`), generates jobs for the current day, clears existing uncompleted jobs for that property/day, and inserts new job rows.
- Added a `Create Jobs` button to the admin property detail panel in `components/admin/ClientListManager.tsx` with UI state (`creatingJobs`) and a client-side fetch to `POST /api/admin/jobs/create` and status messaging.

### Testing

- Started the dev server with `npm run dev`; the server failed to run end-to-end because required Supabase env vars were not present (expected failure).
- Ran a Playwright script to load `/admin/clients` and capture a screenshot; the script completed and produced an artifact, however the page returned a 404 due to the local server middleware error caused by missing Supabase env vars.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530cc1634c8332a24609b02d859d20)